### PR TITLE
Initial add of a config module.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,9 @@ matrix:
   include:
     - python: 3.6
       env: TOXENV=flake8
+    - python: 3.7
+      dist: xenial
+      sudo: true
 
 # Command to run tests, e.g. python setup.py test
 script: tox

--- a/Pipfile
+++ b/Pipfile
@@ -4,12 +4,7 @@ verify_ssl = true
 name = "pypi"
 
 [dev-packages]
-flake8 = "*"
-pylint = "*"
-pytest = "*"
+pytest = "< 3.7"
 coverage = "*"
 
 [packages]
-
-[requires]
-python_version = "3.6"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,12 +1,10 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "a30cc346e58dea6fc2f2852a53bd39593580c2ca36fb103eb1ac930996d20d09"
+            "sha256": "9317c82cae17108544c7336b6bd4642addfd1d107228510c4166260c9ec5dee2"
         },
         "pipfile-spec": 6,
-        "requires": {
-            "python_version": "3.6"
-        },
+        "requires": {},
         "sources": [
             {
                 "name": "pypi",
@@ -17,36 +15,29 @@
     },
     "default": {},
     "develop": {
-        "astroid": {
-            "hashes": [
-                "sha256:0ef2bf9f07c3150929b25e8e61b5198c27b0dca195e156f0e4d5bdd89185ca1a",
-                "sha256:fc9b582dba0366e63540982c3944a9230cbc6f303641c51483fa547dcc22393a"
-            ],
-            "version": "==1.6.5"
-        },
         "atomicwrites": {
             "hashes": [
-                "sha256:240831ea22da9ab882b551b31d4225591e5e447a68c5e188db5b89ca1d487585",
-                "sha256:a24da68318b08ac9c9c45029f4a10371ab5b20e4226738e150e6e7c571630ae6"
+                "sha256:0312ad34fcad8fac3704d441f7b317e50af620823353ec657a53e981f92920c0",
+                "sha256:ec9ae8adaae229e4f8446952d204a3e4b5fdd2d099f9be3aaf556120135fb3ee"
             ],
-            "version": "==1.1.5"
+            "version": "==1.2.1"
         },
         "attrs": {
             "hashes": [
-                "sha256:4b90b09eeeb9b88c35bc642cbac057e45a5fd85367b985bd2809c62b7b939265",
-                "sha256:e0d0eb91441a3b53dab4d9b743eafc1ac44476296a2053b6ca3af0b139faf87b"
+                "sha256:10cbf6e27dbce8c30807caf056c8eb50917e0eaafe86347671b57254006c3e69",
+                "sha256:ca4be454458f9dec299268d472aaa5a11f67a4ff70093396e1ceae9c76cf4bbb"
             ],
-            "version": "==18.1.0"
+            "version": "==18.2.0"
         },
         "coverage": {
             "hashes": [
                 "sha256:03481e81d558d30d230bc12999e3edffe392d244349a90f4ef9b88425fac74ba",
                 "sha256:0b136648de27201056c1869a6c0d4e23f464750fd9a9ba9750b8336a244429ed",
-                "sha256:104ab3934abaf5be871a583541e8829d6c19ce7bde2923b2751e0d3ca44db60a",
-                "sha256:15b111b6a0f46ee1a485414a52a7ad1d703bdf984e9ed3c288a4414d3871dcbd",
+                "sha256:10a46017fef60e16694a30627319f38a2b9b52e90182dddb6e37dcdab0f4bf95",
                 "sha256:198626739a79b09fa0a2f06e083ffd12eb55449b5f8bfdbeed1df4910b2ca640",
-                "sha256:1c383d2ef13ade2acc636556fd544dba6e14fa30755f26812f54300e401f98f2",
+                "sha256:23d341cdd4a0371820eb2b0bd6b88f5003a7438bbedb33688cd33b8eae59affd",
                 "sha256:28b2191e7283f4f3568962e373b47ef7f0392993bb6660d079c62bd50fe9d162",
+                "sha256:2a5b73210bad5279ddb558d9a2bfedc7f4bf6ad7f3c988641d83c40293deaec1",
                 "sha256:2eb564bbf7816a9d68dd3369a510be3327f1c618d2357fa6b1216994c2e3d508",
                 "sha256:337ded681dd2ef9ca04ef5d93cfc87e52e09db2594c296b4a0a3662cb1b41249",
                 "sha256:3a2184c6d797a125dca8367878d3b9a178b6fdd05fdc2d35d758c3006a1cd694",
@@ -66,129 +57,44 @@
                 "sha256:7e1fe19bd6dce69d9fd159d8e4a80a8f52101380d5d3a4d374b6d3eae0e5de9c",
                 "sha256:8c3cb8c35ec4d9506979b4cf90ee9918bc2e49f84189d9bf5c36c0c1119c6558",
                 "sha256:9d6dd10d49e01571bf6e147d3b505141ffc093a06756c60b053a859cb2128b1f",
-                "sha256:9e112fcbe0148a6fa4f0a02e8d58e94470fc6cb82a5481618fea901699bf34c4",
-                "sha256:ac4fef68da01116a5c117eba4dd46f2e06847a497de5ed1d64bb99a5fda1ef91",
-                "sha256:b8815995e050764c8610dbc82641807d196927c3dbed207f0a079833ffcf588d",
                 "sha256:be6cfcd8053d13f5f5eeb284aa8a814220c3da1b0078fa859011c7fffd86dab9",
                 "sha256:c1bb572fab8208c400adaf06a8133ac0712179a334c09224fb11393e920abcdd",
                 "sha256:de4418dadaa1c01d497e539210cb6baa015965526ff5afc078c57ca69160108d",
                 "sha256:e05cb4d9aad6233d67e0541caa7e511fa4047ed7750ec2510d466e806e0255d6",
-                "sha256:e4d96c07229f58cb686120f168276e434660e4358cc9cf3b0464210b04913e77",
-                "sha256:f3f501f345f24383c0000395b26b726e46758b71393267aeae0bd36f8b3ade80",
-                "sha256:f8a923a85cb099422ad5a2e345fe877bbc89a8a8b23235824a93488150e45f6e"
+                "sha256:f3f501f345f24383c0000395b26b726e46758b71393267aeae0bd36f8b3ade80"
             ],
             "index": "pypi",
             "version": "==4.5.1"
         },
-        "flake8": {
-            "hashes": [
-                "sha256:7253265f7abd8b313e3892944044a365e3f4ac3fcdcfb4298f55ee9ddf188ba0",
-                "sha256:c7841163e2b576d435799169b78703ad6ac1bbb0f199994fc05f700b2a90ea37"
-            ],
-            "index": "pypi",
-            "version": "==3.5.0"
-        },
-        "isort": {
-            "hashes": [
-                "sha256:1153601da39a25b14ddc54955dbbacbb6b2d19135386699e2ad58517953b34af",
-                "sha256:b9c40e9750f3d77e6e4d441d8b0266cf555e7cdabdcff33c4fd06366ca761ef8",
-                "sha256:ec9ef8f4a9bc6f71eec99e1806bfa2de401650d996c59330782b89a5555c1497"
-            ],
-            "version": "==4.3.4"
-        },
-        "lazy-object-proxy": {
-            "hashes": [
-                "sha256:0ce34342b419bd8f018e6666bfef729aec3edf62345a53b537a4dcc115746a33",
-                "sha256:1b668120716eb7ee21d8a38815e5eb3bb8211117d9a90b0f8e21722c0758cc39",
-                "sha256:209615b0fe4624d79e50220ce3310ca1a9445fd8e6d3572a896e7f9146bbf019",
-                "sha256:27bf62cb2b1a2068d443ff7097ee33393f8483b570b475db8ebf7e1cba64f088",
-                "sha256:27ea6fd1c02dcc78172a82fc37fcc0992a94e4cecf53cb6d73f11749825bd98b",
-                "sha256:2c1b21b44ac9beb0fc848d3993924147ba45c4ebc24be19825e57aabbe74a99e",
-                "sha256:2df72ab12046a3496a92476020a1a0abf78b2a7db9ff4dc2036b8dd980203ae6",
-                "sha256:320ffd3de9699d3892048baee45ebfbbf9388a7d65d832d7e580243ade426d2b",
-                "sha256:50e3b9a464d5d08cc5227413db0d1c4707b6172e4d4d915c1c70e4de0bbff1f5",
-                "sha256:5276db7ff62bb7b52f77f1f51ed58850e315154249aceb42e7f4c611f0f847ff",
-                "sha256:61a6cf00dcb1a7f0c773ed4acc509cb636af2d6337a08f362413c76b2b47a8dd",
-                "sha256:6ae6c4cb59f199d8827c5a07546b2ab7e85d262acaccaacd49b62f53f7c456f7",
-                "sha256:7661d401d60d8bf15bb5da39e4dd72f5d764c5aff5a86ef52a042506e3e970ff",
-                "sha256:7bd527f36a605c914efca5d3d014170b2cb184723e423d26b1fb2fd9108e264d",
-                "sha256:7cb54db3535c8686ea12e9535eb087d32421184eacc6939ef15ef50f83a5e7e2",
-                "sha256:7f3a2d740291f7f2c111d86a1c4851b70fb000a6c8883a59660d95ad57b9df35",
-                "sha256:81304b7d8e9c824d058087dcb89144842c8e0dea6d281c031f59f0acf66963d4",
-                "sha256:933947e8b4fbe617a51528b09851685138b49d511af0b6c0da2539115d6d4514",
-                "sha256:94223d7f060301b3a8c09c9b3bc3294b56b2188e7d8179c762a1cda72c979252",
-                "sha256:ab3ca49afcb47058393b0122428358d2fbe0408cf99f1b58b295cfeb4ed39109",
-                "sha256:bd6292f565ca46dee4e737ebcc20742e3b5be2b01556dafe169f6c65d088875f",
-                "sha256:cb924aa3e4a3fb644d0c463cad5bc2572649a6a3f68a7f8e4fbe44aaa6d77e4c",
-                "sha256:d0fc7a286feac9077ec52a927fc9fe8fe2fabab95426722be4c953c9a8bede92",
-                "sha256:ddc34786490a6e4ec0a855d401034cbd1242ef186c20d79d2166d6a4bd449577",
-                "sha256:e34b155e36fa9da7e1b7c738ed7767fc9491a62ec6af70fe9da4a057759edc2d",
-                "sha256:e5b9e8f6bda48460b7b143c3821b21b452cb3a835e6bbd5dd33aa0c8d3f5137d",
-                "sha256:e81ebf6c5ee9684be8f2c87563880f93eedd56dd2b6146d8a725b50b7e5adb0f",
-                "sha256:eb91be369f945f10d3a49f5f9be8b3d0b93a4c2be8f8a5b83b0571b8123e0a7a",
-                "sha256:f460d1ceb0e4a5dcb2a652db0904224f367c9b3c1470d5a7683c0480e582468b"
-            ],
-            "version": "==1.3.1"
-        },
-        "mccabe": {
-            "hashes": [
-                "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42",
-                "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"
-            ],
-            "version": "==0.6.1"
-        },
         "more-itertools": {
             "hashes": [
-                "sha256:2b6b9893337bfd9166bee6a62c2b0c9fe7735dcf85948b387ec8cba30e85d8e8",
-                "sha256:6703844a52d3588f951883005efcf555e49566a48afd4db4e965d69b883980d3",
-                "sha256:a18d870ef2ffca2b8463c0070ad17b5978056f403fb64e3f15fe62a52db21cc0"
+                "sha256:c187a73da93e7a8acc0001572aebc7e3c69daf7bf6881a2cea10650bd4420092",
+                "sha256:c476b5d3a34e12d40130bc2f935028b5f636df8f372dc2c1c01dc19681b2039e",
+                "sha256:fcbfeaea0be121980e15bc97b3817b5202ca73d0eae185b4550cbfce2a3ebb3d"
             ],
-            "version": "==4.2.0"
+            "version": "==4.3.0"
         },
         "pluggy": {
             "hashes": [
-                "sha256:7f8ae7f5bdf75671a718d2daf0a64b7885f74510bcd98b1a0bb420eb9a9d0cff",
-                "sha256:d345c8fe681115900d6da8d048ba67c25df42973bda370783cd58826442dcd7c",
-                "sha256:e160a7fcf25762bb60efc7e171d4497ff1d8d2d75a3d0df7a21b76821ecbf5c5"
+                "sha256:6e3836e39f4d36ae72840833db137f7b7d35105079aee6ec4a62d9f80d594dd1",
+                "sha256:95eb8364a4708392bae89035f45341871286a333f749c3141c20573d2b3876e1"
             ],
-            "version": "==0.6.0"
+            "version": "==0.7.1"
         },
         "py": {
             "hashes": [
-                "sha256:3fd59af7435864e1a243790d322d763925431213b6b8529c6ca71081ace3bbf7",
-                "sha256:e31fb2767eb657cbde86c454f02e99cb846d3cd9d61b318525140214fdc0e98e"
-            ],
-            "version": "==1.5.4"
-        },
-        "pycodestyle": {
-            "hashes": [
-                "sha256:682256a5b318149ca0d2a9185d365d8864a768a28db66a84a2ea946bcc426766",
-                "sha256:6c4245ade1edfad79c3446fadfc96b0de2759662dc29d07d80a6f27ad1ca6ba9"
-            ],
-            "version": "==2.3.1"
-        },
-        "pyflakes": {
-            "hashes": [
-                "sha256:08bd6a50edf8cffa9fa09a463063c425ecaaf10d1eb0335a7e8b1401aef89e6f",
-                "sha256:8d616a382f243dbf19b54743f280b80198be0bca3a5396f1d2e1fca6223e8805"
+                "sha256:06a30435d058473046be836d3fc4f27167fd84c45b99704f2fb5509ef61f9af1",
+                "sha256:50402e9d1c9005d759426988a492e0edaadb7f4e68bcddfea586bc7432d009c6"
             ],
             "version": "==1.6.0"
         },
-        "pylint": {
-            "hashes": [
-                "sha256:a48070545c12430cfc4e865bf62f5ad367784765681b3db442d8230f0960aa3c",
-                "sha256:fff220bcb996b4f7e2b0f6812fd81507b72ca4d8c4d05daf2655c333800cb9b3"
-            ],
-            "index": "pypi",
-            "version": "==1.9.2"
-        },
         "pytest": {
             "hashes": [
-                "sha256:0453c8676c2bee6feb0434748b068d5510273a916295fd61d306c4f22fbfd752",
-                "sha256:4b208614ae6d98195430ad6bde03641c78553acee7c83cec2e85d613c0cd383d"
+                "sha256:341ec10361b64a24accaec3c7ba5f7d5ee1ca4cebea30f76fad3dd12db9f0541",
+                "sha256:952c0389db115437f966c4c2079ae9d54714b9455190e56acebe14e8c38a7efa"
             ],
             "index": "pypi",
-            "version": "==3.6.3"
+            "version": "==3.6.4"
         },
         "six": {
             "hashes": [
@@ -196,12 +102,6 @@
                 "sha256:832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb"
             ],
             "version": "==1.11.0"
-        },
-        "wrapt": {
-            "hashes": [
-                "sha256:d4d560d479f2c21e1b5443bbd15fe7ec4b37fe7e53d335d3b9b0a7b1226fe3c6"
-            ],
-            "version": "==1.10.11"
         }
     }
 }

--- a/atkinson/config/__init__.py
+++ b/atkinson/config/__init__.py
@@ -1,0 +1,1 @@
+#! /usr/bin/env python

--- a/atkinson/config/search.py
+++ b/atkinson/config/search.py
@@ -1,0 +1,39 @@
+#! /usr/bin/env python
+"""Search tools for configuration files"""
+
+from __future__ import print_function
+
+import os
+
+
+def _check_available(filename):   # pragma: no cover
+    """Check to see if the filename exists and is a file"""
+    return os.path.exists(filename) and os.path.isfile(filename)
+
+
+def config_search_paths(override_list=None):
+    """Generate a list of paths to search for config files"""
+    default = [os.path.expanduser('~/.atkinson'), '/etc/atkinson', os.path.realpath('./configs')]
+    if override_list is None:
+        return default
+
+    ret_list = []
+    if isinstance(override_list, list):
+        for raw in override_list:
+            ret_list.append(os.path.realpath(os.path.expanduser(raw)))
+    else:
+        ret_list = [os.path.realpath(os.path.expanduser(override_list))]
+
+    ret_list.extend(default)
+    return ret_list
+
+
+def get_config_file(filename='config.yml', overrides=None):
+    """Search for filename, or return the default config file"""
+    ret_path = ''
+    for path in config_search_paths(override_list=overrides):
+        full_path = os.path.join(path, filename)
+        if _check_available(full_path):
+            ret_path = full_path
+            break
+    return ret_path

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     include_package_data=True,
     keywords='atkinson',
     name='atkinson',
-    packages=find_packages(include=['atkinson']),
+    packages=find_packages(include=['atkinson.*']),
     setup_requires=setup_requirements,
     test_suite='tests',
     tests_require=test_requirements,

--- a/tests/config/test_search.py
+++ b/tests/config/test_search.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""Tests for `atkinson` package."""
+
+import os
+
+from unittest.mock import patch
+from atkinson.config import search
+
+
+def base_search_paths():
+    """Helper function to generate the basic results"""
+    home = os.environ['HOME']
+    ret_list = [os.path.join(home, '.atkinson'),
+                '/etc/atkinson',
+                os.path.realpath('./configs')]
+    return ret_list
+
+
+def test_config_path_no_override():
+    """Test we only get our paths"""
+    assert search.config_search_paths() == base_search_paths()
+
+
+def test_cofig_path_override():
+    """Test if a single override is added"""
+    expected = ['/opt']
+    expected.extend(base_search_paths())
+    assert search.config_search_paths('/opt') == expected
+
+
+def test_config_path_override_list():
+    """Test if a list of overrides is added"""
+    expected = ['/opt', '/usr/share']
+    expected.extend(base_search_paths())
+    assert search.config_search_paths(['/opt', '/usr/share']) == expected
+
+
+def test_config_path_with_user():
+    """Test if a list that contains a path with ~ is expanded"""
+    expected = [os.path.join(os.environ['HOME'], 'my_configs')]
+    expected.extend(base_search_paths())
+    assert search.config_search_paths('~/my_configs') == expected
+
+
+def test_conf_path_list_user():
+    """Test override list has a path with ~"""
+    expected = [os.path.join(os.environ['HOME'], 'my_configs')]
+    expected.extend(base_search_paths())
+    assert search.config_search_paths(['~/my_configs']) == expected
+
+
+def test_default_returned_slot_1():
+    """Test config returned from ~/.atkinson"""
+    with patch('atkinson.config.search._check_available') as aval_mock:
+        aval_mock.return_value = True
+        assert search.get_config_file() == os.path.expanduser('~/.atkinson/config.yml')
+
+
+def test_default_returned_slot_2():
+    """Test config returned from /etc/atkinson"""
+    with patch('atkinson.config.search._check_available') as aval_mock:
+        aval_mock.side_effect = [False, True]
+        assert search.get_config_file() == '/etc/atkinson/config.yml'
+
+
+def test_default_returned_slot_3():
+    """Test config returned from ./config"""
+    with patch('atkinson.config.search._check_available') as aval_mock:
+        aval_mock.side_effect = [False, False, True]
+        assert search.get_config_file() == os.path.realpath('./configs/config.yml')
+
+
+def test_default_not_found():
+    """Test config can't be found in the default paths"""
+    with patch('atkinson.config.search._check_available') as aval_mock:
+        aval_mock.side_effect = [False, False, False]
+        assert search.get_config_file() == ''
+
+
+def test_custom_returned_slot_1():
+    """Test config returned from ~/.atkinson"""
+    with patch('atkinson.config.search._check_available') as aval_mock:
+        aval_mock.side_effect = [True]
+        expected = os.path.expanduser('~/.atkinson/my_config.yml')
+        assert search.get_config_file(filename='my_config.yml') == expected
+
+
+def test_custom_returned_slot_2():
+    """Test config returned from /etc/atkinson"""
+    with patch('atkinson.config.search._check_available') as aval_mock:
+        aval_mock.side_effect = [False, True]
+        assert search.get_config_file(filename='my_config.yml') == '/etc/atkinson/my_config.yml'
+
+
+def test_custom_returned_slot_3():
+    """Test config returned from ./config"""
+    with patch('atkinson.config.search._check_available') as aval_mock:
+        aval_mock.side_effect = [False, False, True]
+        expected = os.path.realpath('./configs/my_config.yml')
+        assert search.get_config_file(filename='my_config.yml') == expected
+
+
+def test_default_override():
+    """Test default config from override"""
+    with patch('atkinson.config.search._check_available') as aval_mock:
+        aval_mock.side_effect = [True]
+        expected = os.path.expanduser('~/my_config_dir/config.yml')
+        assert search.get_config_file(overrides='~/my_config_dir') == expected
+
+
+def test_default_override_not_found():
+    """Test an override is given but the file is not found. Fall back to the defaults."""
+    with patch('atkinson.config.search._check_available') as aval_mock:
+        aval_mock.side_effect = [False, True]
+        expected = os.path.expanduser('~/.atkinson/config.yml')
+        assert search.get_config_file(overrides=['~/my_config_dir']) == expected
+
+
+def test_default_second_override():
+    """Test overrides are given, the file is found in the second."""
+    with patch('atkinson.config.search._check_available') as aval_mock:
+        aval_mock.side_effect = [False, True]
+        my_overrides = ['~/my_config_dir', '~/my_second_configs']
+        expected = os.path.expanduser('~/my_second_configs/config.yml')
+        assert search.get_config_file(overrides=my_overrides) == expected

--- a/tox.ini
+++ b/tox.ini
@@ -1,17 +1,23 @@
 [tox]
-envlist = py34, py35, py36, flake8
+envlist = py34, py35, py36, py37, flake8
 
 [travis]
 python =
+    3.7: py37
     3.6: py36
     3.5: py35
     3.4: py34
 
 [testenv]
-passenv=HOME
+passenv=HOME USER
 sitepackages = False
+deps = pipenv
+whitelist_externals = pip
+		      python
 commands =
-    python setup.py test
+    pipenv install --dev --ignore-pipfile
+    pip install -e .
+    pipenv run pytest tests
 
 [testenv:flake8]
 passenv=HOME


### PR DESCRIPTION
Adding a configuration module with unit tests. The first set of
features are functions to enable searching for config files.

- Updated travis and tox to support python 3.4 - 3.7
- Updated the pipenv to have the correct locked versions of pytest to
  support python 3.4 and 3.5
- Updated setup.py to support modules.

Signed-off-by: Jason Joyce <fuzzball81@gmail.com>