### PR TITLE
Rotating config search functions to generators.

### DIFF
--- a/atkinson/config/search.py
+++ b/atkinson/config/search.py
@@ -6,34 +6,63 @@ from __future__ import print_function
 import os
 
 
+# Using a tuple here over a list to insure it's immutable.
+DEFAULT_CONFIG_PATHS = (os.path.realpath('./configs'),
+                        '/etc/atkinson',
+                        os.path.expanduser('~/.atkinson'))
+
+
 def _check_available(filename):   # pragma: no cover
-    """Check to see if the filename exists and is a file"""
+    """
+    Check to see if the filename exists and is a file
+
+    :param filename: str A fully qualified path and file
+    :returns: Boolean
+    """
     return os.path.exists(filename) and os.path.isfile(filename)
 
 
 def config_search_paths(override_list=None):
-    """Generate a list of paths to search for config files"""
-    default = [os.path.expanduser('~/.atkinson'), '/etc/atkinson', os.path.realpath('./configs')]
-    if override_list is None:
-        return default
+    """
+    Generate a list of paths to search for config files
 
-    ret_list = []
-    if isinstance(override_list, list):
-        for raw in override_list:
-            ret_list.append(os.path.realpath(os.path.expanduser(raw)))
-    else:
-        ret_list = [os.path.realpath(os.path.expanduser(override_list))]
+    :param override_list: A list for string path to use as a override location Default: None
+    :returns: generator function of search paths.
+    """
+    for default in DEFAULT_CONFIG_PATHS:
+        yield default
 
-    ret_list.extend(default)
-    return ret_list
+    if override_list is not None:
+        if isinstance(override_list, list):
+            for override_path in override_list:
+                yield os.path.realpath(os.path.expanduser(override_path))
+        else:
+            yield os.path.realpath(os.path.expanduser(override_list))
 
 
-def get_config_file(filename='config.yml', overrides=None):
-    """Search for filename, or return the default config file"""
-    ret_path = ''
+def get_config_files(filenames=None, overrides=None, add_defaults=True):
+    """
+    Search for filename, or return the default config file
+
+    :param filenames: list or string of file names to search for Default: None
+    :param overrides: list of string of paths to use for searching Default: None
+    :param add_defaults: Boolean Control if the default file name (config.yml) is added
+    to the search
+
+    :returns: generator function of available config files
+    """
+    file_names = []
+    if add_defaults is True:
+        file_names.append('config.yml')
+
+    if filenames is not None:
+        if isinstance(filenames, list):
+            file_names.extend(filenames)
+        else:
+            file_names.append(filenames)
+
     for path in config_search_paths(override_list=overrides):
-        full_path = os.path.join(path, filename)
-        if _check_available(full_path):
-            ret_path = full_path
-            break
-    return ret_path
+        for filename in file_names:
+            full_path = os.path.join(path, filename)
+            if _check_available(full_path):
+                yield full_path

--- a/tests/config/test_search.py
+++ b/tests/config/test_search.py
@@ -5,123 +5,152 @@
 
 import os
 
+import pytest
+
 from unittest.mock import patch
 from atkinson.config import search
 
 
-def base_search_paths():
-    """Helper function to generate the basic results"""
-    home = os.environ['HOME']
-    ret_list = [os.path.join(home, '.atkinson'),
-                '/etc/atkinson',
-                os.path.realpath('./configs')]
-    return ret_list
+class CheckAvailMock(object):
+    """Class to control how paths are checked"""
+    def __init__(self, expected):
+        """Constructor"""
+        self.expected = expected
+
+    def check(self, full_path):
+        """Method to match paths that we want"""
+        return full_path in self.expected
 
 
 def test_config_path_no_override():
     """Test we only get our paths"""
-    assert search.config_search_paths() == base_search_paths()
+    assert list(search.config_search_paths()) == list(search.DEFAULT_CONFIG_PATHS)
 
 
 def test_cofig_path_override():
     """Test if a single override is added"""
-    expected = ['/opt']
-    expected.extend(base_search_paths())
-    assert search.config_search_paths('/opt') == expected
+    expected = list(search.DEFAULT_CONFIG_PATHS)
+    expected.append('/opt')
+    assert list(search.config_search_paths('/opt')) == expected
 
 
 def test_config_path_override_list():
     """Test if a list of overrides is added"""
-    expected = ['/opt', '/usr/share']
-    expected.extend(base_search_paths())
-    assert search.config_search_paths(['/opt', '/usr/share']) == expected
+    expected = list(search.DEFAULT_CONFIG_PATHS)
+    expected.extend(['/opt', '/usr/share'])
+    assert list(search.config_search_paths(['/opt', '/usr/share'])) == expected
 
 
 def test_config_path_with_user():
     """Test if a list that contains a path with ~ is expanded"""
-    expected = [os.path.join(os.environ['HOME'], 'my_configs')]
-    expected.extend(base_search_paths())
-    assert search.config_search_paths('~/my_configs') == expected
+    expected = list(search.DEFAULT_CONFIG_PATHS)
+    expected.extend([os.path.join(os.environ['HOME'], 'my_configs')])
+    assert list(search.config_search_paths('~/my_configs')) == expected
 
 
 def test_conf_path_list_user():
     """Test override list has a path with ~"""
-    expected = [os.path.join(os.environ['HOME'], 'my_configs')]
-    expected.extend(base_search_paths())
-    assert search.config_search_paths(['~/my_configs']) == expected
+    expected = list(search.DEFAULT_CONFIG_PATHS)
+    expected.extend([os.path.join(os.environ['HOME'], 'my_configs')])
+    assert list(search.config_search_paths(['~/my_configs'])) == expected
 
 
-def test_default_returned_slot_1():
+def test_default_returned_all():
     """Test config returned from ~/.atkinson"""
     with patch('atkinson.config.search._check_available') as aval_mock:
         aval_mock.return_value = True
-        assert search.get_config_file() == os.path.expanduser('~/.atkinson/config.yml')
+        expected = [os.path.join(x, 'config.yml') for x in search.DEFAULT_CONFIG_PATHS]
+        assert list(search.get_config_files()) == expected
 
 
-def test_default_returned_slot_2():
-    """Test config returned from /etc/atkinson"""
+@pytest.mark.parametrize('expected', [os.path.realpath('./configs/config.yml'),
+                                      '/etc/atkinson/config.yml',
+                                      os.path.expanduser('~/.atkinson/config.yml')])
+def test_default_slots(expected):
+    """Test config returned from each default path individually"""
     with patch('atkinson.config.search._check_available') as aval_mock:
-        aval_mock.side_effect = [False, True]
-        assert search.get_config_file() == '/etc/atkinson/config.yml'
-
-
-def test_default_returned_slot_3():
-    """Test config returned from ./config"""
-    with patch('atkinson.config.search._check_available') as aval_mock:
-        aval_mock.side_effect = [False, False, True]
-        assert search.get_config_file() == os.path.realpath('./configs/config.yml')
+        check = CheckAvailMock(expected)
+        aval_mock.side_effect = check.check
+        assert list(search.get_config_files()) == [expected]
 
 
 def test_default_not_found():
     """Test config can't be found in the default paths"""
     with patch('atkinson.config.search._check_available') as aval_mock:
-        aval_mock.side_effect = [False, False, False]
-        assert search.get_config_file() == ''
+        aval_mock.return_value = False
+        assert list(search.get_config_files()) == []
 
 
-def test_custom_returned_slot_1():
-    """Test config returned from ~/.atkinson"""
+@pytest.mark.parametrize('expected_path', list(search.DEFAULT_CONFIG_PATHS))
+def test_custom_returned_slot(expected_path):
+    """Test custom config file name can be returned from the default paths"""
     with patch('atkinson.config.search._check_available') as aval_mock:
-        aval_mock.side_effect = [True]
-        expected = os.path.expanduser('~/.atkinson/my_config.yml')
-        assert search.get_config_file(filename='my_config.yml') == expected
-
-
-def test_custom_returned_slot_2():
-    """Test config returned from /etc/atkinson"""
-    with patch('atkinson.config.search._check_available') as aval_mock:
-        aval_mock.side_effect = [False, True]
-        assert search.get_config_file(filename='my_config.yml') == '/etc/atkinson/my_config.yml'
-
-
-def test_custom_returned_slot_3():
-    """Test config returned from ./config"""
-    with patch('atkinson.config.search._check_available') as aval_mock:
-        aval_mock.side_effect = [False, False, True]
-        expected = os.path.realpath('./configs/my_config.yml')
-        assert search.get_config_file(filename='my_config.yml') == expected
+        file_name = 'my_config.yml'
+        expected = [os.path.join(expected_path, file_name)]
+        check = CheckAvailMock(expected)
+        aval_mock.side_effect = check.check
+        assert list(search.get_config_files(filenames=file_name)) == expected
 
 
 def test_default_override():
     """Test default config from override"""
     with patch('atkinson.config.search._check_available') as aval_mock:
-        aval_mock.side_effect = [True]
-        expected = os.path.expanduser('~/my_config_dir/config.yml')
-        assert search.get_config_file(overrides='~/my_config_dir') == expected
+        file_name = 'config.yml'
+        override = '~/my_config_dir'
+        expected = [os.path.join(os.path.expanduser(override), file_name)]
+        check = CheckAvailMock(expected)
+        aval_mock.side_effect = check.check
+        assert list(search.get_config_files(overrides=override)) == expected
 
 
 def test_default_override_not_found():
     """Test an override is given but the file is not found. Fall back to the defaults."""
     with patch('atkinson.config.search._check_available') as aval_mock:
-        aval_mock.side_effect = [False, True]
-        expected = os.path.expanduser('~/.atkinson/config.yml')
-        assert search.get_config_file(overrides=['~/my_config_dir']) == expected
+        my_overrides = ['~/my_config_dir']
+        file_name = 'config.yml'
+        expected = [os.path.join(os.path.expanduser(x), file_name) for x in my_overrides]
+        check = CheckAvailMock(expected)
+        aval_mock.side_effect = check.check
+        assert list(search.get_config_files(overrides=my_overrides)) == expected
 
 
 def test_default_second_override():
     """Test overrides are given, the file is found in the second."""
     with patch('atkinson.config.search._check_available') as aval_mock:
-        aval_mock.side_effect = [False, True]
         my_overrides = ['~/my_config_dir', '~/my_second_configs']
-        expected = os.path.expanduser('~/my_second_configs/config.yml')
-        assert search.get_config_file(overrides=my_overrides) == expected
+        file_name = 'config.yml'
+        expected = [os.path.join(os.path.expanduser(x), file_name) for x in my_overrides]
+        check = CheckAvailMock(expected)
+        aval_mock.side_effect = check.check
+        assert list(search.get_config_files(overrides=my_overrides)) == expected
+
+
+def test_several_confs_no_override():
+    """ Test that several configs can be found"""
+    with patch('atkinson.config.search._check_available') as aval_mock:
+        file_names = ['configA.yml', 'configB.yml']
+        expected = [os.path.join('/etc/atkinson', x) for x in file_names]
+        check = CheckAvailMock(expected)
+        aval_mock.side_effect = check.check
+        assert list(search.get_config_files(filenames=file_names)) == expected
+
+
+def test_several_confs_mix_override():
+    """Test that several configs can be found in overrides and defaults"""
+    with patch('atkinson.config.search._check_available') as aval_mock:
+        file_names = ['configA.yml', 'configB.yml']
+        override = '/opt/configs'
+        expected = ['/etc/atkinson/configB.yml', '/opt/configs/configA.yml']
+        check = CheckAvailMock(expected)
+        aval_mock.side_effect = check.check
+        assert list(search.get_config_files(filenames=file_names, overrides=override)) == expected
+
+
+def test_override_extra_defaults():
+    """Test an extra filename, override and default filename returns the correct order"""
+    with patch('atkinson.config.search._check_available') as aval_mock:
+        override = '/opt/configs'
+        expected = ['/opt/configs/config.yml', '/opt/configs/extra.yml']
+        check = CheckAvailMock(expected)
+        aval_mock.side_effect = check.check
+        assert list(search.get_config_files(filenames='extra.yml', overrides=override)) == expected


### PR DESCRIPTION
Changing config_search_paths and get_config_files to be generators
instead of functions that return lists. This allows for better
performance and less memory usage. The other benefit is a config manager
can better handle stacked configs where you may have overrides in one
file but want the defaults from another.

Pulled the default search paths to a global constant to make testing
easier.

Adding the ability to pass get_config_files a list of file names to
search for and have found paths returned.

Signed-off-by: Jason Joyce <fuzzball81@gmail.com>