### PR TITLE
Using setup.py as the source or truth for dependencies

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,10 +4,11 @@ verify_ssl = true
 name = "pypi"
 
 [dev-packages]
-pytest = "< 3.7"
+pytest = "*"
 coverage = "*"
-sphinx-rtd-theme = "*"
-sphinx = "*"
 sphinx-autobuild = "*"
+sphinx_rtd_theme = "*"
+Sphinx = "*"
 
 [packages]
+

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "efae769fd7e0fe03fc4740c996e8236ccd5abef42c90790addf60332cc62e80c"
+            "sha256": "9944826797c3b850359a00713c91d7800d72551a88729cc1111f980d2a10abdd"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -17,10 +17,10 @@
     "develop": {
         "alabaster": {
             "hashes": [
-                "sha256:674bb3bab080f598371f4443c5008cbfeb1a5e622dd312395d2d82af2c54c456",
-                "sha256:b63b1f4dc77c074d386752ec4a8a7517600f6c0db8cd42980cae17ab7b3275d7"
+                "sha256:446438bdcca0e05bd45ea2de1668c1d9b032e1a9154c2c259092d77031ddd359",
+                "sha256:a661d72d58e6ea8a57f7a86e37d86716863ee5e92788398526d58b26a4e4dc02"
             ],
-            "version": "==0.7.11"
+            "version": "==0.7.12"
         },
         "argh": {
             "hashes": [
@@ -202,11 +202,11 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:341ec10361b64a24accaec3c7ba5f7d5ee1ca4cebea30f76fad3dd12db9f0541",
-                "sha256:952c0389db115437f966c4c2079ae9d54714b9455190e56acebe14e8c38a7efa"
+                "sha256:7e258ee50338f4e46957f9e09a0f10fb1c2d05493fa901d113a8dafd0790de4e",
+                "sha256:9332147e9af2dcf46cd7ceb14d5acadb6564744ddff1fe8c17f0ce60ece7d9a2"
             ],
             "index": "pypi",
-            "version": "==3.6.4"
+            "version": "==3.8.2"
         },
         "pytz": {
             "hashes": [
@@ -273,7 +273,6 @@
                 "sha256:3b49758a64f8a1ebd8a33cb6cc9093c3935a908b716edfaa5772fd86aac27ef6",
                 "sha256:80e01ec0eb711abacb1fa507f3eae8b805ae8fa3e8b057abfdf497e3f644c82c"
             ],
-            "index": "pypi",
             "version": "==0.4.1"
         },
         "sphinxcontrib-websupport": {

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,0 +1,2 @@
+-i https://pypi.python.org/simple
+.[test,docs]

--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -1,0 +1,2 @@
+-i https://pypi.python.org/simple
+-e .[docs]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+-i https://pypi.python.org/simple
+-e .

--- a/setup.py
+++ b/setup.py
@@ -11,11 +11,7 @@ with open('README.rst') as readme_file:
 with open('HISTORY.rst') as history_file:
     history = history_file.read()
 
-requirements = []
-
-setup_requirements = ['pytest-runner', ]
-
-test_requirements = ['pytest', 'flake8']
+TEST_REQUIRES = ['pytest', 'pytest-datadir', 'coverage']
 
 setup(
     author="Jason Joyce",
@@ -31,16 +27,18 @@ setup(
         'Programming Language :: Python :: 3.6',
     ],
     description="Python based release manager.",
-    install_requires=requirements,
+    setup_requires=['pytest-runner'],
+    install_requires=['pyyaml==3.13'],
+    tests_require=TEST_REQUIRES,
+    extras_require={'docs': ['sphinx', 'sphinx-autobuild', 'sphinx-rtd-theme'],
+                    'test': TEST_REQUIRES},
     license="MIT license",
     long_description=readme + '\n\n' + history,
     include_package_data=True,
     keywords='atkinson',
     name='atkinson',
     packages=find_packages(include=['atkinson.*']),
-    setup_requires=setup_requirements,
     test_suite='tests',
-    tests_require=test_requirements,
     url='https://github.com/release-depot/atkinson',
     version='0.0.1',
     zip_safe=False,

--- a/tox.ini
+++ b/tox.ini
@@ -1,26 +1,20 @@
 [tox]
-envlist = py34, py35, py36, py37, flake8
+envlist = py36, py37, flake8
 
 [travis]
 python =
     3.7: py37
     3.6: py36
-    3.5: py35
-    3.4: py34
 
 [testenv]
-passenv=HOME USER
+passenv = HOME USER
 sitepackages = False
-deps = pipenv
-whitelist_externals = pip
-		      python
+whitelist_externals = python
 commands =
-    pipenv install --dev --ignore-pipfile
-    pip install -e .
-    pipenv run pytest tests
+	python setup.py test
 
 [testenv:flake8]
-passenv=HOME
+passenv = HOME
 deps = flake8
 sitepackages = False
 commands =


### PR DESCRIPTION
Making setup.py hold all of the dependencies needed instead of using a
the Pipfile and/or requirements files.

Added requirements files for easier env setup via pip and for
readthedocs.

Signed-off-by: Jason Joyce <fuzzball81@gmail.com>