### PR TITLE
Add support for a pluggable logger.

### DIFF
--- a/atkinson/logging/__init__.py
+++ b/atkinson/logging/__init__.py
@@ -1,0 +1,1 @@
+#! /usr/bin/env python

--- a/atkinson/logging/drivers/default.py
+++ b/atkinson/logging/drivers/default.py
@@ -1,0 +1,23 @@
+#! /usr/bin/env python
+"""Implementation of a driver that uses the standard python logger."""
+
+import logging
+import logging.config
+
+
+def getLogger(config):
+    """
+    Returns a python stdlib logger
+
+    :param config:  Dictionary of values meeting the criteria in the
+                    `Configuration dictionary schema
+                    <https://docs.python.org/3.7/library/logging.config.html#logging-config-dictschema>`_.
+
+    """
+    if 'version' not in config:
+        config['version'] = 1
+    if len(config) > 2:
+        logging.config.dictConfig(config)
+    logger = logging.getLogger(__name__)
+    logger.setLevel(config.get('root', {}).get('level', logging.WARNING))
+    return logger

--- a/atkinson/logging/logger.py
+++ b/atkinson/logging/logger.py
@@ -1,0 +1,42 @@
+#! /usr/bin/env python
+"""Interface to get a configured logger"""
+
+import importlib
+
+
+def getLogger(config=None):
+    """
+    Returns a logger object of the type specified.
+
+    :param config: Dictionary of values to configure the desired logger object.
+
+    For example, to use the default python logger, you can
+    either simply pass None, or specify any details supported by
+    the atkinson default driver for the python logger.  You
+    would specify the default logger (with custom loglevel) with:
+    ::
+
+      {'driver':'atkinson.logging.drivers.default',
+      'root':{'level':DEBUG}}
+
+    The atkinson logging wrapper code specifies a toplevel element in the
+    config dict of 'driver', pointing at the driver that will load the
+    desired configuration and return a logger to use.
+
+    Each driver must implement getLogger, so we can invoke it the same way from
+    this interface. In theory, drivers could be released as separate modules.
+
+    """
+    if not config:
+        config = _default_config()
+    try:
+        module = importlib.import_module(config.get('driver'))
+        return module.getLogger(config)
+    except ModuleNotFoundError as e:
+        logger = getLogger(_default_config())
+        logger.error('Loading the default driver, {0}'.format(e.msg))
+        return logger
+
+
+def _default_config():
+    return {'driver': 'atkinson.logging.drivers.default'}

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -1,0 +1,41 @@
+"""Test logging functionality"""
+
+import logging
+from unittest.mock import MagicMock
+from atkinson.logging import logger
+
+
+def test_gets_default_logger():
+    """
+    GIVEN we request a logger with the default atkinson logger
+    WHEN we specify the root log level
+    THEN we get back a default python logger, with that level set.
+    """
+    mylogger = logger.getLogger({'driver': 'atkinson.logging.drivers.default',
+                                'root': {'level': 'DEBUG'}})
+    assert isinstance(mylogger, logging.Logger)
+    assert mylogger.getEffectiveLevel() == logging.DEBUG
+
+
+def test_no_logger_specified():
+    """
+    GIVEN we request a logger without specifying any details
+    THEN we get back a default python logger with log level = WARNING
+    """
+    mylogger = logger.getLogger()
+    assert isinstance(mylogger, logging.Logger)
+    assert mylogger.getEffectiveLevel() == logging.WARNING
+
+
+def test_driver_not_found():
+    """
+    GIVEN we request a logger with a driver that cannot be found
+    THEN we get back a default python logger with log level = WARNING
+    """
+    logging.Logger.error = MagicMock()
+    mylogger = logger.getLogger({'driver': 'foo.bar.baz'})
+
+    mylogger.error.assert_called_with(
+        "Loading the default driver, No module named 'foo'")
+    assert isinstance(mylogger, logging.Logger)
+    assert mylogger.getEffectiveLevel() == logging.WARNING


### PR DESCRIPTION
This patch adds a generic call to get a logger, and a default
implementation, which uses the standard python logging libraries.  The
user can specify to the getLogger(config) method call which logging
system they want by providing a 'driver' entry in their config file.
This should be the fully qualified module name, and can be anywhere that
python can see it.  For the default driver, you can set any settings
supported by the dictConfig method, which is to say, all python logging
configuration.