### PR TITLE
Fixing line length pylint warnings in tests

### DIFF
--- a/tests/config/test_manager.py
+++ b/tests/config/test_manager.py
@@ -27,7 +27,9 @@ def test_default_name_ignore_paths(datadir):
 
 def test_default_ignored_other_name(datadir):
     """Test if we give a custom name, it is loaded ignoring the defaults"""
-    manager = ConfigManager(filenames='override.yml', paths=datadir, defaults=False)
+    manager = ConfigManager(filenames='override.yml',
+                            paths=datadir,
+                            defaults=False)
     expected = {'my_option': {'setting2': True}}
     assert manager.config == expected
 
@@ -41,9 +43,12 @@ def test_override_wins(datadir):
 
 def test_complex_override(datadir):
     """Test that a deep nested dict and list update"""
-    manager = ConfigManager(filenames=['complex.yml', 'complex_override.yml'], paths=datadir)
+    manager = ConfigManager(filenames=['complex.yml', 'complex_override.yml'],
+                            paths=datadir)
     expected = {'my_option': {'extra': True,
-                              'nested': {'more_nested': {'even_more_nested': True}},
+                              'nested': {
+                                  'more_nested': {
+                                      'even_more_nested': True}},
                               'setting1': True,
                               'setting2': True,
                               'setting_list': [3, 2, 1]}}


### PR DESCRIPTION
A few of the lines in the Configuration module's tests were longer then
the recommended 79 characters. Fixing those lines.

Also refactored one of the tests to support using the default paths from
the search module.

Signed-off-by: Jason Joyce <fuzzball81@gmail.com>