### PR TITLE
Rotating the configuration manager to use toolchest.

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -12,4 +12,4 @@ sphinx_rtd_theme = "*"
 Sphinx = "*"
 
 [packages]
-pyyaml = "*"
+toolchest = ">=0.0.4"

--- a/atkinson/config/manager.py
+++ b/atkinson/config/manager.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python
 """Module for loading/accessing config data"""
 
-import yaml
+from toolchest import yaml
 
 from atkinson.config.search import get_config_files
 
@@ -47,7 +47,7 @@ class ConfigManager():
         :param filename: The fully qualified path to load and parse
         """
         with open(filename, 'r') as file_handle:
-            data = yaml.safe_load(file_handle.read())
+            data = yaml.parse(file_handle.read())
             self.config_data = _update(self._config_data, data)
             self._config_files.append(filename)
 

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     ],
     description="Python based release manager.",
     setup_requires=['pytest-runner'],
-    install_requires=['pyyaml==3.13'],
+    install_requires=['toolchest>=0.0.4'],
     tests_require=TEST_REQUIRES,
     extras_require={'docs': ['sphinx', 'sphinx-autobuild', 'sphinx-rtd-theme'],
                     'test': TEST_REQUIRES},


### PR DESCRIPTION
Now that toolchest has a yaml parser, use that in place of using pyyaml
directly.

Signed-off-by: Jason Joyce <fuzzball81@gmail.com>