### PR TITLE
Adding a dlrn sub-module

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -10,6 +10,8 @@ coverage = "*"
 sphinx-autobuild = "*"
 sphinx_rtd_theme = "*"
 Sphinx = "*"
+requests-mock = "*"
 
 [packages]
 toolchest = ">=0.0.4"
+requests = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "e31a8cb04aba87abd9e0a88b7d474f9ecac97c8d8dd195d54f37e6cf7b2fefc1"
+            "sha256": "071454399f8537e5140a26f72e017a3e018fb29526c73681ff708fcd352f4f38"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -14,6 +14,27 @@
         ]
     },
     "default": {
+        "certifi": {
+            "hashes": [
+                "sha256:339dc09518b07e2fa7eda5450740925974815557727d6bd35d319c1524a04a4c",
+                "sha256:6d58c986d22b038c8c0df30d639f23a3e6d172a05c3583e766f4c0b785c0986a"
+            ],
+            "version": "==2018.10.15"
+        },
+        "chardet": {
+            "hashes": [
+                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae",
+                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
+            ],
+            "version": "==3.0.4"
+        },
+        "idna": {
+            "hashes": [
+                "sha256:156a6814fb5ac1fc6850fb002e0852d56c0c8d2531923a51032d1b70760e186e",
+                "sha256:684a38a6f903c1d71d6d5fac066b58d7768af4de2b832e426ec79c30daa94a16"
+            ],
+            "version": "==2.7"
+        },
         "pyyaml": {
             "hashes": [
                 "sha256:3d7da3009c0f3e783b2c873687652d83b1bbfd5c88e9813fb7e5b03c0dd3108b",
@@ -28,8 +49,31 @@
                 "sha256:e01d3203230e1786cd91ccfdc8f8454c8069c91bee3962ad93b87a4b2860f537",
                 "sha256:e170a9e6fcfd19021dd29845af83bb79236068bf5fd4df3327c1be18182b2531"
             ],
-            "index": "pypi",
             "version": "==3.13"
+        },
+        "requests": {
+            "hashes": [
+                "sha256:65b3a120e4329e33c9889db89c80976c5272f56ea92d3e74da8a463992e3ff54",
+                "sha256:ea881206e59f41dbd0bd445437d792e43906703fff75ca8ff43ccdb11f33f263"
+            ],
+            "index": "pypi",
+            "version": "==2.20.1"
+        },
+        "toolchest": {
+            "hashes": [
+                "sha256:2439e3ea68057cd931a2dd43721159012ff50d998965db7e973939e801e3441a",
+                "sha256:c2ff8ab1ce493f3d8f092d2343506d5b62bdb630567a6ae30ce936011e12005c"
+            ],
+            "index": "pypi",
+            "version": "==0.0.4"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:61bf29cada3fc2fbefad4fdf059ea4bd1b4a86d2b6d15e1c7c0b582b9752fe39",
+                "sha256:de9529817c93f27c8ccbfead6985011db27bd0ddfcdb2d86f3f663385c6a9c22"
+            ],
+            "markers": "python_version != '3.2.*' and python_version != '3.1.*' and python_version != '3.0.*' and python_version < '4' and python_version >= '2.7' and python_version != '3.3.*'",
+            "version": "==1.24.1"
         }
     },
     "develop": {
@@ -70,10 +114,10 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:376690d6f16d32f9d1fe8932551d80b23e9d393a8578c5633a2ed39a64861638",
-                "sha256:456048c7e371c089d0a77a5212fb37a2c2dce1e24146e3b7e0261736aaeaa22a"
+                "sha256:339dc09518b07e2fa7eda5450740925974815557727d6bd35d319c1524a04a4c",
+                "sha256:6d58c986d22b038c8c0df30d639f23a3e6d172a05c3583e766f4c0b785c0986a"
             ],
-            "version": "==2018.8.24"
+            "version": "==2018.10.15"
         },
         "chardet": {
             "hashes": [
@@ -84,40 +128,40 @@
         },
         "coverage": {
             "hashes": [
-                "sha256:03481e81d558d30d230bc12999e3edffe392d244349a90f4ef9b88425fac74ba",
-                "sha256:0b136648de27201056c1869a6c0d4e23f464750fd9a9ba9750b8336a244429ed",
-                "sha256:10a46017fef60e16694a30627319f38a2b9b52e90182dddb6e37dcdab0f4bf95",
-                "sha256:198626739a79b09fa0a2f06e083ffd12eb55449b5f8bfdbeed1df4910b2ca640",
-                "sha256:23d341cdd4a0371820eb2b0bd6b88f5003a7438bbedb33688cd33b8eae59affd",
-                "sha256:28b2191e7283f4f3568962e373b47ef7f0392993bb6660d079c62bd50fe9d162",
-                "sha256:2a5b73210bad5279ddb558d9a2bfedc7f4bf6ad7f3c988641d83c40293deaec1",
-                "sha256:2eb564bbf7816a9d68dd3369a510be3327f1c618d2357fa6b1216994c2e3d508",
-                "sha256:337ded681dd2ef9ca04ef5d93cfc87e52e09db2594c296b4a0a3662cb1b41249",
-                "sha256:3a2184c6d797a125dca8367878d3b9a178b6fdd05fdc2d35d758c3006a1cd694",
-                "sha256:3c79a6f7b95751cdebcd9037e4d06f8d5a9b60e4ed0cd231342aa8ad7124882a",
-                "sha256:3d72c20bd105022d29b14a7d628462ebdc61de2f303322c0212a054352f3b287",
-                "sha256:3eb42bf89a6be7deb64116dd1cc4b08171734d721e7a7e57ad64cc4ef29ed2f1",
-                "sha256:4635a184d0bbe537aa185a34193898eee409332a8ccb27eea36f262566585000",
-                "sha256:56e448f051a201c5ebbaa86a5efd0ca90d327204d8b059ab25ad0f35fbfd79f1",
-                "sha256:5a13ea7911ff5e1796b6d5e4fbbf6952381a611209b736d48e675c2756f3f74e",
-                "sha256:69bf008a06b76619d3c3f3b1983f5145c75a305a0fea513aca094cae5c40a8f5",
-                "sha256:6bc583dc18d5979dc0f6cec26a8603129de0304d5ae1f17e57a12834e7235062",
-                "sha256:701cd6093d63e6b8ad7009d8a92425428bc4d6e7ab8d75efbb665c806c1d79ba",
-                "sha256:7608a3dd5d73cb06c531b8925e0ef8d3de31fed2544a7de6c63960a1e73ea4bc",
-                "sha256:76ecd006d1d8f739430ec50cc872889af1f9c1b6b8f48e29941814b09b0fd3cc",
-                "sha256:7aa36d2b844a3e4a4b356708d79fd2c260281a7390d678a10b91ca595ddc9e99",
-                "sha256:7d3f553904b0c5c016d1dad058a7554c7ac4c91a789fca496e7d8347ad040653",
-                "sha256:7e1fe19bd6dce69d9fd159d8e4a80a8f52101380d5d3a4d374b6d3eae0e5de9c",
-                "sha256:8c3cb8c35ec4d9506979b4cf90ee9918bc2e49f84189d9bf5c36c0c1119c6558",
-                "sha256:9d6dd10d49e01571bf6e147d3b505141ffc093a06756c60b053a859cb2128b1f",
-                "sha256:be6cfcd8053d13f5f5eeb284aa8a814220c3da1b0078fa859011c7fffd86dab9",
-                "sha256:c1bb572fab8208c400adaf06a8133ac0712179a334c09224fb11393e920abcdd",
-                "sha256:de4418dadaa1c01d497e539210cb6baa015965526ff5afc078c57ca69160108d",
-                "sha256:e05cb4d9aad6233d67e0541caa7e511fa4047ed7750ec2510d466e806e0255d6",
-                "sha256:f3f501f345f24383c0000395b26b726e46758b71393267aeae0bd36f8b3ade80"
+                "sha256:09e47c529ff77bf042ecfe858fb55c3e3eb97aac2c87f0349ab5a7efd6b3939f",
+                "sha256:0a1f9b0eb3aa15c990c328535655847b3420231af299386cfe5efc98f9c250fe",
+                "sha256:0cc941b37b8c2ececfed341444a456912e740ecf515d560de58b9a76562d966d",
+                "sha256:10e8af18d1315de936d67775d3a814cc81d0747a1a0312d84e27ae5610e313b0",
+                "sha256:1b4276550b86caa60606bd3572b52769860a81a70754a54acc8ba789ce74d607",
+                "sha256:1e8a2627c48266c7b813975335cfdea58c706fe36f607c97d9392e61502dc79d",
+                "sha256:2b224052bfd801beb7478b03e8a66f3f25ea56ea488922e98903914ac9ac930b",
+                "sha256:447c450a093766744ab53bf1e7063ec82866f27bcb4f4c907da25ad293bba7e3",
+                "sha256:46101fc20c6f6568561cdd15a54018bb42980954b79aa46da8ae6f008066a30e",
+                "sha256:4710dc676bb4b779c4361b54eb308bc84d64a2fa3d78e5f7228921eccce5d815",
+                "sha256:510986f9a280cd05189b42eee2b69fecdf5bf9651d4cd315ea21d24a964a3c36",
+                "sha256:5535dda5739257effef56e49a1c51c71f1d37a6e5607bb25a5eee507c59580d1",
+                "sha256:5a7524042014642b39b1fcae85fb37556c200e64ec90824ae9ecf7b667ccfc14",
+                "sha256:5f55028169ef85e1fa8e4b8b1b91c0b3b0fa3297c4fb22990d46ff01d22c2d6c",
+                "sha256:6694d5573e7790a0e8d3d177d7a416ca5f5c150742ee703f3c18df76260de794",
+                "sha256:6831e1ac20ac52634da606b658b0b2712d26984999c9d93f0c6e59fe62ca741b",
+                "sha256:77f0d9fa5e10d03aa4528436e33423bfa3718b86c646615f04616294c935f840",
+                "sha256:828ad813c7cdc2e71dcf141912c685bfe4b548c0e6d9540db6418b807c345ddd",
+                "sha256:85a06c61598b14b015d4df233d249cd5abfa61084ef5b9f64a48e997fd829a82",
+                "sha256:8cb4febad0f0b26c6f62e1628f2053954ad2c555d67660f28dfb1b0496711952",
+                "sha256:a5c58664b23b248b16b96253880b2868fb34358911400a7ba39d7f6399935389",
+                "sha256:aaa0f296e503cda4bc07566f592cd7a28779d433f3a23c48082af425d6d5a78f",
+                "sha256:ab235d9fe64833f12d1334d29b558aacedfbca2356dfb9691f2d0d38a8a7bfb4",
+                "sha256:b3b0c8f660fae65eac74fbf003f3103769b90012ae7a460863010539bb7a80da",
+                "sha256:bab8e6d510d2ea0f1d14f12642e3f35cefa47a9b2e4c7cea1852b52bc9c49647",
+                "sha256:c45297bbdbc8bb79b02cf41417d63352b70bcb76f1bbb1ee7d47b3e89e42f95d",
+                "sha256:d19bca47c8a01b92640c614a9147b081a1974f69168ecd494687c827109e8f42",
+                "sha256:d64b4340a0c488a9e79b66ec9f9d77d02b99b772c8b8afd46c1294c1d39ca478",
+                "sha256:da969da069a82bbb5300b59161d8d7c8d423bc4ccd3b410a9b4d8932aeefc14b",
+                "sha256:ed02c7539705696ecb7dc9d476d861f3904a8d2b7e894bd418994920935d36bb",
+                "sha256:ee5b8abc35b549012e03a7b1e86c09491457dba6c94112a2482b18589cc2bdb9"
             ],
             "index": "pypi",
-            "version": "==4.5.1"
+            "version": "==4.5.2"
         },
         "docutils": {
             "hashes": [
@@ -158,9 +202,37 @@
         },
         "markupsafe": {
             "hashes": [
-                "sha256:a6be69091dac236ea9c6bc7d012beab42010fa914c459791d627dad4910eb665"
+                "sha256:048ef924c1623740e70204aa7143ec592504045ae4429b59c30054cb31e3c432",
+                "sha256:130f844e7f5bdd8e9f3f42e7102ef1d49b2e6fdf0d7526df3f87281a532d8c8b",
+                "sha256:19f637c2ac5ae9da8bfd98cef74d64b7e1bb8a63038a3505cd182c3fac5eb4d9",
+                "sha256:1b8a7a87ad1b92bd887568ce54b23565f3fd7018c4180136e1cf412b405a47af",
+                "sha256:1c25694ca680b6919de53a4bb3bdd0602beafc63ff001fea2f2fc16ec3a11834",
+                "sha256:1f19ef5d3908110e1e891deefb5586aae1b49a7440db952454b4e281b41620cd",
+                "sha256:1fa6058938190ebe8290e5cae6c351e14e7bb44505c4a7624555ce57fbbeba0d",
+                "sha256:31cbb1359e8c25f9f48e156e59e2eaad51cd5242c05ed18a8de6dbe85184e4b7",
+                "sha256:3e835d8841ae7863f64e40e19477f7eb398674da6a47f09871673742531e6f4b",
+                "sha256:4e97332c9ce444b0c2c38dd22ddc61c743eb208d916e4265a2a3b575bdccb1d3",
+                "sha256:525396ee324ee2da82919f2ee9c9e73b012f23e7640131dd1b53a90206a0f09c",
+                "sha256:52b07fbc32032c21ad4ab060fec137b76eb804c4b9a1c7c7dc562549306afad2",
+                "sha256:52ccb45e77a1085ec5461cde794e1aa037df79f473cbc69b974e73940655c8d7",
+                "sha256:5c3fbebd7de20ce93103cb3183b47671f2885307df4a17a0ad56a1dd51273d36",
+                "sha256:5e5851969aea17660e55f6a3be00037a25b96a9b44d2083651812c99d53b14d1",
+                "sha256:5edfa27b2d3eefa2210fb2f5d539fbed81722b49f083b2c6566455eb7422fd7e",
+                "sha256:7d263e5770efddf465a9e31b78362d84d015cc894ca2c131901a4445eaa61ee1",
+                "sha256:83381342bfc22b3c8c06f2dd93a505413888694302de25add756254beee8449c",
+                "sha256:857eebb2c1dc60e4219ec8e98dfa19553dae33608237e107db9c6078b1167856",
+                "sha256:98e439297f78fca3a6169fd330fbe88d78b3bb72f967ad9961bcac0d7fdd1550",
+                "sha256:bf54103892a83c64db58125b3f2a43df6d2cb2d28889f14c78519394feb41492",
+                "sha256:d9ac82be533394d341b41d78aca7ed0e0f4ba5a2231602e2f05aa87f25c51672",
+                "sha256:e982fe07ede9fada6ff6705af70514a52beb1b2c3d25d4e873e82114cf3c5401",
+                "sha256:edce2ea7f3dfc981c4ddc97add8a61381d9642dc3273737e756517cc03e84dd6",
+                "sha256:efdc45ef1afc238db84cb4963aa689c0408912a0239b0721cb172b4016eb31d6",
+                "sha256:f137c02498f8b935892d5c0172560d7ab54bc45039de8805075e19079c639a9c",
+                "sha256:f82e347a72f955b7017a39708a3667f106e6ad4d10b25f237396a7115d8ed5fd",
+                "sha256:fb7c206e01ad85ce57feeaaa0bf784b97fa3cad0d4a5737bc5295785f5c613a1"
             ],
-            "version": "==1.0"
+            "markers": "python_version != '3.2.*' and python_version != '3.1.*' and python_version != '3.0.*' and python_version >= '2.7' and python_version != '3.3.*'",
+            "version": "==1.1.0"
         },
         "more-itertools": {
             "hashes": [
@@ -185,10 +257,11 @@
         },
         "pluggy": {
             "hashes": [
-                "sha256:6e3836e39f4d36ae72840833db137f7b7d35105079aee6ec4a62d9f80d594dd1",
-                "sha256:95eb8364a4708392bae89035f45341871286a333f749c3141c20573d2b3876e1"
+                "sha256:447ba94990e8014ee25ec853339faf7b0fc8050cdc3289d4d71f7f410fb90095",
+                "sha256:bde19360a8ec4dfd8a20dcb811780a30998101f078fc7ded6162f0076f50508f"
             ],
-            "version": "==0.7.1"
+            "markers": "python_version != '3.2.*' and python_version != '3.3.*' and python_version != '3.1.*' and python_version >= '2.7' and python_version != '3.0.*'",
+            "version": "==0.8.0"
         },
         "port-for": {
             "hashes": [
@@ -198,10 +271,11 @@
         },
         "py": {
             "hashes": [
-                "sha256:06a30435d058473046be836d3fc4f27167fd84c45b99704f2fb5509ef61f9af1",
-                "sha256:50402e9d1c9005d759426988a492e0edaadb7f4e68bcddfea586bc7432d009c6"
+                "sha256:bf92637198836372b520efcba9e020c330123be8ce527e535d185ed4b6f45694",
+                "sha256:e76826342cefe3c3d5f7e8ee4316b80d1dd8a300781612ddbc765c17ba25a6c6"
             ],
-            "version": "==1.6.0"
+            "markers": "python_version != '3.2.*' and python_version != '3.3.*' and python_version != '3.1.*' and python_version >= '2.7' and python_version != '3.0.*'",
+            "version": "==1.7.0"
         },
         "pygments": {
             "hashes": [
@@ -212,19 +286,19 @@
         },
         "pyparsing": {
             "hashes": [
-                "sha256:bc6c7146b91af3f567cf6daeaec360bc07d45ffec4cf5353f4d7a208ce7ca30a",
-                "sha256:d29593d8ebe7b57d6967b62494f8c72b03ac0262b1eed63826c6f788b3606401"
+                "sha256:40856e74d4987de5d01761a22d1621ae1c7f8774585acae358aa5c5936c6c90b",
+                "sha256:f353aab21fd474459d97b709e527b5571314ee5f067441dc9f88e33eecd96592"
             ],
-            "markers": "python_version != '3.0.*' and python_version != '3.2.*' and python_version >= '2.6' and python_version != '3.1.*'",
-            "version": "==2.2.2"
+            "markers": "python_version >= '2.6' and python_version != '3.2.*' and python_version != '3.1.*' and python_version != '3.0.*'",
+            "version": "==2.3.0"
         },
         "pytest": {
             "hashes": [
-                "sha256:7e258ee50338f4e46957f9e09a0f10fb1c2d05493fa901d113a8dafd0790de4e",
-                "sha256:9332147e9af2dcf46cd7ceb14d5acadb6564744ddff1fe8c17f0ce60ece7d9a2"
+                "sha256:488c842647bbeb350029da10325cb40af0a9c7a2fdda45aeb1dda75b60048ffb",
+                "sha256:c055690dfefa744992f563e8c3a654089a6aa5b8092dded9b6fafbd70b2e45a7"
             ],
             "index": "pypi",
-            "version": "==3.8.2"
+            "version": "==4.0.0"
         },
         "pytest-datadir": {
             "hashes": [
@@ -236,10 +310,10 @@
         },
         "pytz": {
             "hashes": [
-                "sha256:a061aa0a9e06881eb8b3b2b43f05b9439d6583c206d0a6c340ff72a7b6669053",
-                "sha256:ffb9ef1de172603304d9d2819af6f5ece76f2e85ec10692a524dd876e72bf277"
+                "sha256:31cb35c89bd7d333cd32c5f278fca91b523b0834369e757f4c5641ea252236ca",
+                "sha256:8e0f8568c118d3077b46be7d654cc8167fa916092e28320cde048e54bfc9f1e6"
             ],
-            "version": "==2018.5"
+            "version": "==2018.7"
         },
         "pyyaml": {
             "hashes": [
@@ -255,15 +329,23 @@
                 "sha256:e01d3203230e1786cd91ccfdc8f8454c8069c91bee3962ad93b87a4b2860f537",
                 "sha256:e170a9e6fcfd19021dd29845af83bb79236068bf5fd4df3327c1be18182b2531"
             ],
-            "index": "pypi",
             "version": "==3.13"
         },
         "requests": {
             "hashes": [
-                "sha256:63b52e3c866428a224f97cab011de738c36aec0185aa91cfacd418b5d58911d1",
-                "sha256:ec22d826a36ed72a7358ff3fe56cbd4ba69dd7a6718ffd450ff0e9df7a47ce6a"
+                "sha256:65b3a120e4329e33c9889db89c80976c5272f56ea92d3e74da8a463992e3ff54",
+                "sha256:ea881206e59f41dbd0bd445437d792e43906703fff75ca8ff43ccdb11f33f263"
             ],
-            "version": "==2.19.1"
+            "index": "pypi",
+            "version": "==2.20.1"
+        },
+        "requests-mock": {
+            "hashes": [
+                "sha256:7a5fa99db5e3a2a961b6f20ed40ee6baeff73503cf0a553cc4d679409e6170fb",
+                "sha256:8ca0628dc66d3f212878932fd741b02aa197ad53fd2228164800a169a4a826af"
+            ],
+            "index": "pypi",
+            "version": "==1.5.2"
         },
         "six": {
             "hashes": [
@@ -281,11 +363,12 @@
         },
         "sphinx": {
             "hashes": [
-                "sha256:652eb8c566f18823a022bb4b6dbc868d366df332a11a0226b5bc3a798a479f17",
-                "sha256:d222626d8356de702431e813a05c68a35967e3d66c6cd1c2c89539bb179a7464"
+                "sha256:120732cbddb1b2364471c3d9f8bfd4b0c5b550862f99a65736c77f970b142aea",
+                "sha256:b348790776490894e0424101af9c8413f2a86831524bd55c5f379d3e3e12ca64"
             ],
             "index": "pypi",
-            "version": "==1.8.1"
+            "markers": "python_version != '3.2.*' and python_version != '3.1.*' and python_version != '3.0.*' and python_version >= '2.7' and python_version != '3.3.*'",
+            "version": "==1.8.2"
         },
         "sphinx-autobuild": {
             "hashes": [
@@ -297,10 +380,10 @@
         },
         "sphinx-rtd-theme": {
             "hashes": [
-                "sha256:3b49758a64f8a1ebd8a33cb6cc9093c3935a908b716edfaa5772fd86aac27ef6",
-                "sha256:80e01ec0eb711abacb1fa507f3eae8b805ae8fa3e8b057abfdf497e3f644c82c"
+                "sha256:02f02a676d6baabb758a20c7a479d58648e0f64f13e07d1b388e9bb2afe86a09",
+                "sha256:d0f6bc70f98961145c5b0e26a992829363a197321ba571b31b24ea91879e0c96"
             ],
-            "version": "==0.4.1"
+            "version": "==0.4.2"
         },
         "sphinxcontrib-websupport": {
             "hashes": [
@@ -324,10 +407,11 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:a68ac5e15e76e7e5dd2b8f94007233e01effe3e50e8daddf69acfd81cb686baf",
-                "sha256:b5725a0bd4ba422ab0e66e89e030c806576753ea3ee08554382c14e685d117b5"
+                "sha256:61bf29cada3fc2fbefad4fdf059ea4bd1b4a86d2b6d15e1c7c0b582b9752fe39",
+                "sha256:de9529817c93f27c8ccbfead6985011db27bd0ddfcdb2d86f3f663385c6a9c22"
             ],
-            "version": "==1.23"
+            "markers": "python_version != '3.2.*' and python_version != '3.1.*' and python_version != '3.0.*' and python_version < '4' and python_version >= '2.7' and python_version != '3.3.*'",
+            "version": "==1.24.1"
         },
         "watchdog": {
             "hashes": [

--- a/atkinson/dlrn/__init__.py
+++ b/atkinson/dlrn/__init__.py
@@ -1,0 +1,1 @@
+#! /usr/bin/env python

--- a/atkinson/dlrn/dlrn.yml
+++ b/atkinson/dlrn/dlrn.yml
@@ -1,0 +1,4 @@
+---
+rdo:
+  url: 'https://trunk.rdoproject.org'
+  release: centos7-master

--- a/atkinson/dlrn/http_data.py
+++ b/atkinson/dlrn/http_data.py
@@ -1,0 +1,160 @@
+#! /usr/bin/env python
+"""Functions for working with the DLRN API"""
+
+import csv
+import os.path
+import requests
+
+from toolchest import yaml
+
+from atkinson.config.manager import ConfigManager
+from atkinson.logging.logger import getLogger
+
+
+def _raw_fetch(url):
+    """
+    Fetch remote data and return the text output.
+
+    :param url: The URL to fetch the data from
+    :return: Raw text data, None otherwise
+    """
+    ret_data = None
+    req = requests.get(url)
+    if req.status_code == requests.codes.ok:
+        ret_data = req.text
+
+    return ret_data
+
+
+def _fetch_yaml(url):
+    """
+    Fetch remote data and process the text as yaml.
+
+    :param url: The URL to fetch the data from
+    :return: Parsed yaml data in the form of a dictionary
+    """
+    ret_data = None
+    raw_data = _raw_fetch(url)
+    if raw_data is not None:
+        ret_data = yaml.parse(raw_data)
+
+    return ret_data
+
+
+def dlrn_http_factory(host, config_file=None, logger=getLogger()):
+    """
+    Create a DlrnData instance based on a host.
+
+    :param host: A host name string to build instances
+    :param config_file: A dlrn config file(s) to use in addition to
+                        the default.
+    :param logger: An atkinson logger to use. Default is the base logger.
+    :return: A DlrnData instance
+    """
+    manager = None
+    files = ['dlrn.yml']
+    if config_file is not None:
+        if isinstance(config_file, list):
+            files.extend(config_file)
+        else:
+            files.append(config_file)
+
+    local_path = os.path.realpath(os.path.dirname(__file__))
+    manager = ConfigManager(filenames=files, paths=local_path)
+
+    if manager is None:
+        return None
+
+    config = manager.config
+    if host not in config:
+        return None
+
+    return DlrnHttpData(config[host]['url'],
+                        config[host]['release'],
+                        logger=logger)
+
+
+class DlrnHttpData():
+    """A class used to interact with the dlrn API"""
+    def __init__(self, url, release, logger=getLogger()):
+        """
+        Class constructor
+
+        :param url: The URL to the host to obtain data.
+        :param releases: The release name to use for lookup.
+        :param logger: An atkinson logger to use. Default is the base logger.
+        """
+        self.url = url
+        self.release = release
+        self._logger = logger
+
+    def _build_url(self, commit_hash, distgit_hash):
+        """
+        Generate a url given a commit hash and distgit hash to match the format
+        base/AB/CD/ABCD123_XYZ987 where ABCD123 is the commit hash and XYZ987
+        is a portion of the distgit hash.
+
+        :param commit_hash: A string with the full commit hash on the change
+        :param dlrn_hash: A string with the full dlrn hash to fetch from
+        :return: A string with the full URL.
+        """
+        first = commit_hash[0:2]
+        second = commit_hash[2:4]
+        third = commit_hash + '_' + distgit_hash[0:8]
+        return os.path.join(self.url, self.release, first, second,
+                            third)
+
+    def commit(self, name):
+        """
+        Get RDO consistent information
+
+        :param name: The name of the link to process E.G. consistent or current
+
+        :return: A list of dictionaries of name, dist-git hash and source hash.
+                 An empty list is returned otherwise.
+        """
+        ret_data = []
+        full_url = os.path.join(self.url,
+                                self.release,
+                                name, 'commit.yaml')
+        data = _fetch_yaml(full_url)
+        if data is not None and 'commits' in data:
+            for pkg in data['commits']:
+                if pkg['status'] == 'SUCCESS':
+                    ret_data.append({'name': pkg['project_name'],
+                                     'dist_hash': pkg['distro_hash'],
+                                     'commit_hash': pkg['commit_hash']})
+                else:
+                    msg = '{0} has a status of error'.format(str(pkg))
+                    self._logger.warning(msg)
+
+        return ret_data
+
+    def get_versions(self, commit_hash, distgit_hash):
+        """
+        Get the version data for the versions.csv file and return the
+        data in a dictionary
+
+        :param commit_hash: A string with the full commit hash on the change
+        :param dlrn_hash: A string with the full dlrn hash to fetch from
+
+        :return: A dictionary of packages with commit and dist-git hashes
+        """
+        ret_dict = {}
+        full_url = os.path.join(self._build_url(commit_hash, distgit_hash),
+                                'versions.csv')
+        data = _raw_fetch(full_url)
+        if data is not None:
+            data = data.replace(' ', '_')
+            split_data = data.split()
+            reader = csv.DictReader(split_data)
+            for row in reader:
+                ret_dict[row['Project']] = {'source': row['Source_Sha'],
+                                            'state': row['Status'],
+                                            'distgit': row['Dist_Sha'],
+                                            'nvr': row['Pkg_NVR']}
+        else:
+            msg = 'Could not fetch {0}'.format(full_url)
+            self._logger.error(msg)
+
+        return ret_dict

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,8 @@ with open('README.rst') as readme_file:
 with open('HISTORY.rst') as history_file:
     history = history_file.read()
 
-TEST_REQUIRES = ['pytest', 'pytest-datadir', 'coverage']
+TEST_REQUIRES = ['pytest', 'pytest-datadir',
+                 'coverage', 'requests-mock']
 
 setup(
     author="Jason Joyce",
@@ -27,7 +28,7 @@ setup(
     ],
     description="Python based release manager.",
     setup_requires=['pytest-runner'],
-    install_requires=['toolchest>=0.0.4'],
+    install_requires=['toolchest>=0.0.4', 'requests'],
     tests_require=TEST_REQUIRES,
     extras_require={'docs': ['sphinx', 'sphinx-autobuild', 'sphinx-rtd-theme'],
                     'test': TEST_REQUIRES},

--- a/tests/unit/dlrn/test_http_data.py
+++ b/tests/unit/dlrn/test_http_data.py
@@ -1,0 +1,147 @@
+#! /usr/bin/env python
+"""Tests for the DLRN api submodule"""
+
+import os.path
+
+import requests_mock
+
+from atkinson.dlrn.http_data import DlrnHttpData, dlrn_http_factory
+
+
+def test_factory_good_config(datadir):
+    """
+    Given we have a valid config file
+    When we call the factory function
+    Then we get a DlrnHttpData instance
+    """
+    config_file = os.path.join(datadir, 'config.yml')
+    actual = dlrn_http_factory('tester', config_file=config_file)
+    assert isinstance(actual, DlrnHttpData)
+
+
+def test_factory_bad_config(datadir):
+    """
+    Given we have a bad config file
+    When we call the factory function
+    Then we get None
+    """
+    config_file = os.path.join(datadir, 'bad.yml')
+    actual = dlrn_http_factory('tester', config_file=config_file)
+    assert actual is None
+
+
+def test_no_data_good_status(datadir):
+    """
+    GIVEN we have a DlrnHttpData instance with a working config
+    WHEN we fetch the commit yaml but it contains no data
+    AND the status code is good.
+    THEN we get an empty list back from the call
+    """
+    config_file = os.path.join(datadir, 'config.yml')
+    with requests_mock.Mocker() as mock:
+        mock.get('http://testhost/test/consistent/commit.yaml',
+                 text='',
+                 status_code=200)
+        dlrn = dlrn_http_factory('tester', config_file=config_file)
+        actual = dlrn.commit('consistent')
+        assert [] == actual
+
+
+def test_no_data_bad_status(datadir):
+    """
+    GIVEN we have a DlrnHttpData instance with a working config
+    WHEN we fetch the commit yaml but get a bad status code
+    THEN we get an empty list back from the call
+    """
+    config_file = os.path.join(datadir, 'config.yml')
+    with requests_mock.Mocker() as mock:
+        mock.get('http://testhost/test/consistent/commit.yaml',
+                 status_code=404)
+        dlrn = dlrn_http_factory('tester', config_file=config_file)
+        actual = dlrn.commit('consistent')
+        assert [] == actual
+
+
+def test_good_data_good_status(datadir):
+    """
+    GIVEN we have a DlrnHttpData instance with a working config
+    WHEN we fetch the commit yaml and it contains data
+    AND the status code is good
+    THEN we get a list of commits back from the call
+    """
+    config_file = os.path.join(datadir, 'config.yml')
+    real_data = os.path.join(datadir, 'commit.yaml')
+    expected = [{'name': 'python-networking-l2gw',
+                 'dist_hash': '44eea44aaa02e9d314c0288788254a9f316c5772',
+                 'commit_hash': '1c087246c4a31bec1124acde610731c884c435f1'}]
+    with open(real_data, 'r') as data:
+        with requests_mock.Mocker() as mock:
+            mock.get('http://testhost/test/consistent/commit.yaml',
+                     text=data.read(),
+                     status_code=200)
+            dlrn = dlrn_http_factory('tester', config_file=config_file)
+            actual = dlrn.commit('consistent')
+            assert expected == actual
+
+
+def test_good_data_bad_status(datadir):
+    """
+    GIVEN we have a DlrnHttpData instance
+    WHEN we fetch the commit yaml and it contains data
+    AND the status code is bad
+    THEN we get a list of commits back from the call
+    """
+    config_file = os.path.join(datadir, 'config.yml')
+    real_data = os.path.join(datadir, 'commit.yaml')
+    with open(real_data, 'r') as data:
+        expected = []
+        with requests_mock.Mocker() as mock:
+            mock.get('http://testhost/test/consistent/commit.yaml',
+                     text=data.read(),
+                     status_code=404)
+            dlrn = dlrn_http_factory('tester', config_file=config_file)
+            actual = dlrn.commit('consistent')
+            assert expected == actual
+
+
+def test_get_versions_good_status(datadir):
+    """
+    GIVEN we have a DlrnHttpData instance and commit and distgit hashs
+    WHEN we call get_versions
+    AND the status code is good
+    THEN we get a dictionary with data
+    """
+    config_file = os.path.join(datadir, 'config.yml')
+    real_data = os.path.join(datadir, 'versions.csv')
+    with open(real_data, 'r') as data:
+        expected = {'test-project': {'source': 'abc123',
+                                     'state': 'SUCCESS',
+                                     'distgit': 'zxy987',
+                                     'nvr': 'test-project-1.0.el7'}}
+        with requests_mock.Mocker() as mock:
+            mock.get('http://testhost/test/ab/c1/abc123_zxy987/versions.csv',
+                     text=data.read(),
+                     status_code=200)
+            dlrn = dlrn_http_factory('tester', config_file=config_file)
+            actual = dlrn.get_versions('abc123', 'zxy987')
+            assert expected == actual
+
+
+def test_get_versions_bad_status(datadir):
+    """
+    GIVEN we have a DlrnHttpData instance and commit and distgit hashs
+    WHEN we call get_versions
+    AND the status code is bad
+    THEN we get an empty dictionary
+    """
+    config_file = os.path.join(datadir, 'config.yml')
+    real_data = os.path.join(datadir, 'versions.csv')
+    with open(real_data, 'r') as data:
+        expected = {}
+        with requests_mock.Mocker() as mock:
+            mock.get('http://testhost/test/ab/c1/abc123_zxy987/versions.csv',
+                     text=data.read(),
+                     status_code=404)
+            dlrn = dlrn_http_factory('tester', config_file=config_file)
+            actual = dlrn.get_versions('abc123', 'zxy987')
+            assert expected == actual

--- a/tests/unit/dlrn/test_http_data/commit.yaml
+++ b/tests/unit/dlrn/test_http_data/commit.yaml
@@ -1,0 +1,15 @@
+commits:
+- commit_branch: master
+  commit_hash: 1c087246c4a31bec1124acde610731c884c435f1
+  distgit_dir: /home/centos-master-uc/data/python-networking-l2gw_distro/
+  distro_hash: 44eea44aaa02e9d314c0288788254a9f316c5772
+  dt_build: '1541157889'
+  dt_commit: '1541157342.0'
+  dt_distro: '1535033997'
+  flags: '0'
+  id: '61971'
+  notes: OK
+  project_name: python-networking-l2gw
+  repo_dir: /home/centos-master-uc/data/python-networking-l2gw
+  rpms: repos/1c/08/1c087246c4a31bec1124acde610731c884c435f1_44eea44a/python-networking-l2gw-13.0.1-0.20181102112457.1c08724.el7.src.rpm,repos/1c/08/1c087246c4a31bec1124acde610731c884c435f1_44eea44a/openstack-neutron-l2gw-agent-13.0.1-0.20181102112457.1c08724.el7.noarch.rpm,repos/1c/08/1c087246c4a31bec1124acde610731c884c435f1_44eea44a/python-networking-l2gw-tests-13.0.1-0.20181102112457.1c08724.el7.noarch.rpm,repos/1c/08/1c087246c4a31bec1124acde610731c884c435f1_44eea44a/python-networking-l2gw-doc-13.0.1-0.20181102112457.1c08724.el7.noarch.rpm,repos/1c/08/1c087246c4a31bec1124acde610731c884c435f1_44eea44a/python2-networking-l2gw-13.0.1-0.20181102112457.1c08724.el7.noarch.rpm
+  status: SUCCESS

--- a/tests/unit/dlrn/test_http_data/config.yml
+++ b/tests/unit/dlrn/test_http_data/config.yml
@@ -1,0 +1,4 @@
+---
+tester:
+  url: 'http://testhost'
+  release: 'test'

--- a/tests/unit/dlrn/test_http_data/versions.csv
+++ b/tests/unit/dlrn/test_http_data/versions.csv
@@ -1,0 +1,2 @@
+Project,Source Repo,Source Sha,Dist Repo,Dist Sha,Status,Last Success Timestamp,Pkg NVR
+test-project,https://github.com/release-depot/test-project.git,abc123,https://github.com/release-depot/test-project-distgit.git,zxy987,SUCCESS,1541991102,test-project-1.0.el7


### PR DESCRIPTION
This is the start of a dlrn module the will start to drive atkinson.
This portion handles a few of the basic http requests that we have to
make to extract version data and what the current commit is for a given
promoted link.

We now rely on toolchest version 0.0.4 or greater for some of the
functionality.

Signed-off-by: Jason Joyce <fuzzball81@gmail.com>