### PR TITLE
Fixing an issue where dlrn extended hashes were not supported.

### DIFF
--- a/atkinson/dlrn/http_data.py
+++ b/atkinson/dlrn/http_data.py
@@ -11,43 +11,51 @@ from atkinson.config.manager import ConfigManager
 from atkinson.logging.logger import getLogger
 
 
-def _raw_fetch(url):
+def _raw_fetch(url, logger):
     """
     Fetch remote data and return the text output.
 
     :param url: The URL to fetch the data from
+    :param logger: A logger instance to use.
     :return: Raw text data, None otherwise
     """
     ret_data = None
-    req = requests.get(url)
-    if req.status_code == requests.codes.ok:
-        ret_data = req.text
+    try:
+        req = requests.get(url)
+        if req.status_code == requests.codes.ok:
+            ret_data = req.text
+    except requests.exceptions.ConnectionError as error:
+        logger.warning(error.request)
 
     return ret_data
 
 
-def _fetch_yaml(url):
+def _fetch_yaml(url, logger):
     """
     Fetch remote data and process the text as yaml.
 
     :param url: The URL to fetch the data from
+    :param logger: A logger instance to use.
     :return: Parsed yaml data in the form of a dictionary
     """
     ret_data = None
-    raw_data = _raw_fetch(url)
+    raw_data = _raw_fetch(url, logger)
     if raw_data is not None:
         ret_data = yaml.parse(raw_data)
 
     return ret_data
 
 
-def dlrn_http_factory(host, config_file=None, logger=getLogger()):
+def dlrn_http_factory(host, config_file=None, link_name=None,
+                      logger=getLogger()):
     """
     Create a DlrnData instance based on a host.
 
     :param host: A host name string to build instances
     :param config_file: A dlrn config file(s) to use in addition to
                         the default.
+    :param link_name: A dlrn symlink to use. This overrides the config files
+                      link parameter.
     :param logger: An atkinson logger to use. Default is the base logger.
     :return: A DlrnData instance
     """
@@ -69,81 +77,94 @@ def dlrn_http_factory(host, config_file=None, logger=getLogger()):
     if host not in config:
         return None
 
+    link = config[host]['link']
+    if link_name is not None:
+        link = link_name
+
     return DlrnHttpData(config[host]['url'],
                         config[host]['release'],
+                        link_name=link,
                         logger=logger)
 
 
 class DlrnHttpData():
     """A class used to interact with the dlrn API"""
-    def __init__(self, url, release, logger=getLogger()):
+    def __init__(self, url, release, link_name='current', logger=getLogger()):
         """
         Class constructor
 
         :param url: The URL to the host to obtain data.
         :param releases: The release name to use for lookup.
+        :param link_name: The name of the dlrn symlink to fetch data from.
         :param logger: An atkinson logger to use. Default is the base logger.
         """
-        self.url = url
+        self.url = os.path.join(url, release)
         self.release = release
         self._logger = logger
+        self._link_name = link_name
+        self._commit_data = {}
+        self._fetch_commit()
 
-    def _build_url(self, commit_hash, distgit_hash):
+    def _fetch_commit(self):
+        """
+        Fetch the commit data from dlrn
+        """
+        full_url = os.path.join(self.url,
+                                self._link_name,
+                                'commit.yaml')
+        data = _fetch_yaml(full_url, self._logger)
+        if data is not None and 'commits' in data:
+            pkg = data['commits'][0]
+            if pkg['status'] == 'SUCCESS':
+                self._commit_data = {'name': pkg['project_name'],
+                                     'dist_hash': pkg['distro_hash'],
+                                     'commit_hash': pkg['commit_hash'],
+                                     'extended_hash': pkg.get('extended_hash')}
+            else:
+                msg = '{0} has a status of error'.format(str(pkg))
+                self._logger.warning(msg)
+
+    def _build_url(self):
         """
         Generate a url given a commit hash and distgit hash to match the format
         base/AB/CD/ABCD123_XYZ987 where ABCD123 is the commit hash and XYZ987
         is a portion of the distgit hash.
 
-        :param commit_hash: A string with the full commit hash on the change
-        :param dlrn_hash: A string with the full dlrn hash to fetch from
         :return: A string with the full URL.
         """
-        first = commit_hash[0:2]
-        second = commit_hash[2:4]
-        third = commit_hash + '_' + distgit_hash[0:8]
-        return os.path.join(self.url, self.release, first, second,
+        first = self._commit_data['commit_hash'][0:2]
+        second = self._commit_data['commit_hash'][2:4]
+        third = self._commit_data['commit_hash']
+        for key in ['dist_hash', 'extended_hash']:
+            if self._commit_data.get(key):
+                third += '_' + self._commit_data[key][0:8]
+        return os.path.join(self.url,
+                            first,
+                            second,
                             third)
 
-    def commit(self, name):
+    @property
+    def commit(self):
         """
-        Get RDO consistent information
+        Get the dlrn commit information
 
-        :param name: The name of the link to process E.G. consistent or current
-
-        :return: A list of dictionaries of name, dist-git hash and source hash.
-                 An empty list is returned otherwise.
+        :return: A dictionary of name, dist-git hash, commit hash and
+                 extended hash.
+                 An empty dictionary is returned otherwise.
         """
-        ret_data = []
-        full_url = os.path.join(self.url,
-                                self.release,
-                                name, 'commit.yaml')
-        data = _fetch_yaml(full_url)
-        if data is not None and 'commits' in data:
-            for pkg in data['commits']:
-                if pkg['status'] == 'SUCCESS':
-                    ret_data.append({'name': pkg['project_name'],
-                                     'dist_hash': pkg['distro_hash'],
-                                     'commit_hash': pkg['commit_hash']})
-                else:
-                    msg = '{0} has a status of error'.format(str(pkg))
-                    self._logger.warning(msg)
+        return self._commit_data
 
-        return ret_data
-
-    def get_versions(self, commit_hash, distgit_hash):
+    @property
+    def versions(self):
         """
         Get the version data for the versions.csv file and return the
         data in a dictionary
 
-        :param commit_hash: A string with the full commit hash on the change
-        :param dlrn_hash: A string with the full dlrn hash to fetch from
-
         :return: A dictionary of packages with commit and dist-git hashes
         """
         ret_dict = {}
-        full_url = os.path.join(self._build_url(commit_hash, distgit_hash),
-                                'versions.csv')
-        data = _raw_fetch(full_url)
+        full_url = os.path.join(self._build_url(), 'versions.csv')
+        data = _raw_fetch(full_url, self._logger)
         if data is not None:
             data = data.replace(' ', '_')
             split_data = data.split()

--- a/tests/unit/dlrn/test_http_data.py
+++ b/tests/unit/dlrn/test_http_data.py
@@ -8,7 +8,7 @@ import requests_mock
 from atkinson.dlrn.http_data import DlrnHttpData, dlrn_http_factory
 
 
-def test_factory_good_config(datadir):
+def test_factory_bad_connnection(datadir):
     """
     Given we have a valid config file
     When we call the factory function
@@ -35,31 +35,29 @@ def test_no_data_good_status(datadir):
     GIVEN we have a DlrnHttpData instance with a working config
     WHEN we fetch the commit yaml but it contains no data
     AND the status code is good.
-    THEN we get an empty list back from the call
+    THEN we get an empty dictionary back from the call
     """
     config_file = os.path.join(datadir, 'config.yml')
     with requests_mock.Mocker() as mock:
-        mock.get('http://testhost/test/consistent/commit.yaml',
+        mock.get('http://testhost/test/link_name/commit.yaml',
                  text='',
                  status_code=200)
         dlrn = dlrn_http_factory('tester', config_file=config_file)
-        actual = dlrn.commit('consistent')
-        assert [] == actual
+        assert {} == dlrn.commit
 
 
 def test_no_data_bad_status(datadir):
     """
     GIVEN we have a DlrnHttpData instance with a working config
     WHEN we fetch the commit yaml but get a bad status code
-    THEN we get an empty list back from the call
+    THEN we get an empty dictionary back from the call
     """
     config_file = os.path.join(datadir, 'config.yml')
     with requests_mock.Mocker() as mock:
-        mock.get('http://testhost/test/consistent/commit.yaml',
+        mock.get('http://testhost/test/link_name/commit.yaml',
                  status_code=404)
         dlrn = dlrn_http_factory('tester', config_file=config_file)
-        actual = dlrn.commit('consistent')
-        assert [] == actual
+        assert {} == dlrn.commit
 
 
 def test_good_data_good_status(datadir):
@@ -67,21 +65,21 @@ def test_good_data_good_status(datadir):
     GIVEN we have a DlrnHttpData instance with a working config
     WHEN we fetch the commit yaml and it contains data
     AND the status code is good
-    THEN we get a list of commits back from the call
+    THEN we get a commit data back from the call
     """
     config_file = os.path.join(datadir, 'config.yml')
     real_data = os.path.join(datadir, 'commit.yaml')
-    expected = [{'name': 'python-networking-l2gw',
-                 'dist_hash': '44eea44aaa02e9d314c0288788254a9f316c5772',
-                 'commit_hash': '1c087246c4a31bec1124acde610731c884c435f1'}]
+    expected = {'name': 'python-networking-l2gw',
+                'dist_hash': '44eea44aaa02e9d314c0288788254a9f316c5772',
+                'commit_hash': '1c087246c4a31bec1124acde610731c884c435f1',
+                'extended_hash': None}
     with open(real_data, 'r') as data:
         with requests_mock.Mocker() as mock:
-            mock.get('http://testhost/test/consistent/commit.yaml',
+            mock.get('http://testhost/test/link_name/commit.yaml',
                      text=data.read(),
                      status_code=200)
             dlrn = dlrn_http_factory('tester', config_file=config_file)
-            actual = dlrn.commit('consistent')
-            assert expected == actual
+            assert expected == dlrn.commit
 
 
 def test_good_data_bad_status(datadir):
@@ -94,26 +92,47 @@ def test_good_data_bad_status(datadir):
     config_file = os.path.join(datadir, 'config.yml')
     real_data = os.path.join(datadir, 'commit.yaml')
     with open(real_data, 'r') as data:
-        expected = []
+        expected = {}
         with requests_mock.Mocker() as mock:
-            mock.get('http://testhost/test/consistent/commit.yaml',
+            mock.get('http://testhost/test/link_name/commit.yaml',
                      text=data.read(),
                      status_code=404)
             dlrn = dlrn_http_factory('tester', config_file=config_file)
-            actual = dlrn.commit('consistent')
-            assert expected == actual
+            assert expected == dlrn.commit
+
+
+def test_extended_hash(datadir):
+    """
+    GIVEN we have a DlrnHttpData instance
+    WHEN we have commit data that has an extended hash
+    THEN the commit data contains a hash instead of None
+    """
+    config_file = os.path.join(datadir, 'config.yml')
+    real_data = os.path.join(datadir, 'extend_commit.yaml')
+    expected = {'name': 'test-package',
+                'dist_hash': 'zyx987',
+                'commit_hash': 'abc123',
+                'extended_hash': 'asdf567'}
+    with open(real_data, 'r') as data:
+        with requests_mock.Mocker() as mock:
+            mock.get('http://testhost/test/link_name/commit.yaml',
+                     text=data.read(),
+                     status_code=200)
+            dlrn = dlrn_http_factory('tester', config_file=config_file)
+            assert expected == dlrn.commit
 
 
 def test_get_versions_good_status(datadir):
     """
-    GIVEN we have a DlrnHttpData instance and commit and distgit hashs
-    WHEN we call get_versions
+    GIVEN we have a DlrnHttpData instance
+    WHEN we call versions
     AND the status code is good
     THEN we get a dictionary with data
     """
     config_file = os.path.join(datadir, 'config.yml')
     real_data = os.path.join(datadir, 'versions.csv')
-    with open(real_data, 'r') as data:
+    commit_data = os.path.join(datadir, 'test_commit.yaml')
+    with open(real_data, 'r') as data, open(commit_data, 'r') as commit:
         expected = {'test-project': {'source': 'abc123',
                                      'state': 'SUCCESS',
                                      'distgit': 'zxy987',
@@ -122,26 +141,58 @@ def test_get_versions_good_status(datadir):
             mock.get('http://testhost/test/ab/c1/abc123_zxy987/versions.csv',
                      text=data.read(),
                      status_code=200)
+            mock.get('http://testhost/test/link_name/commit.yaml',
+                     text=commit.read(),
+                     status_code=200)
             dlrn = dlrn_http_factory('tester', config_file=config_file)
-            actual = dlrn.get_versions('abc123', 'zxy987')
-            assert expected == actual
+            assert expected == dlrn.versions
 
 
 def test_get_versions_bad_status(datadir):
     """
-    GIVEN we have a DlrnHttpData instance and commit and distgit hashs
-    WHEN we call get_versions
+    GIVEN we have a DlrnHttpData instance
+    WHEN we call versions
     AND the status code is bad
     THEN we get an empty dictionary
     """
     config_file = os.path.join(datadir, 'config.yml')
     real_data = os.path.join(datadir, 'versions.csv')
-    with open(real_data, 'r') as data:
+    commit_data = os.path.join(datadir, 'test_commit.yaml')
+    with open(real_data, 'r') as data, open(commit_data, 'r') as commit:
         expected = {}
         with requests_mock.Mocker() as mock:
             mock.get('http://testhost/test/ab/c1/abc123_zxy987/versions.csv',
                      text=data.read(),
                      status_code=404)
+            mock.get('http://testhost/test/link_name/commit.yaml',
+                     text=commit.read(),
+                     status_code=200)
             dlrn = dlrn_http_factory('tester', config_file=config_file)
-            actual = dlrn.get_versions('abc123', 'zxy987')
-            assert expected == actual
+            assert expected == dlrn.versions
+
+
+def test_extend_hash_version(datadir):
+    """
+    GIVEN we have a DlrnHttpData instance and commit data with an extended hash
+    WHEN we call versions
+    THEN we get a dictionary with data
+    """
+    config_file = os.path.join(datadir, 'config.yml')
+    real_data = os.path.join(datadir, 'versions.csv')
+    commit_data = os.path.join(datadir, 'extend_commit.yaml')
+    with open(real_data, 'r') as data, open(commit_data, 'r') as commit:
+        expected = {'test-project': {'source': 'abc123',
+                                     'state': 'SUCCESS',
+                                     'distgit': 'zxy987',
+                                     'nvr': 'test-project-1.0.el7'}}
+        with requests_mock.Mocker() as mock:
+            url1 = ('http://testhost/test/ab/c1/abc123_zyx987'
+                    '_asdf567/versions.csv')
+            mock.get(url1,
+                     text=data.read(),
+                     status_code=200)
+            mock.get('http://testhost/test/link_name/commit.yaml',
+                     text=commit.read(),
+                     status_code=200)
+            dlrn = dlrn_http_factory('tester', config_file=config_file)
+            assert expected == dlrn.versions

--- a/tests/unit/dlrn/test_http_data/config.yml
+++ b/tests/unit/dlrn/test_http_data/config.yml
@@ -2,3 +2,4 @@
 tester:
   url: 'http://testhost'
   release: 'test'
+  link: 'link_name'

--- a/tests/unit/dlrn/test_http_data/extend_commit.yaml
+++ b/tests/unit/dlrn/test_http_data/extend_commit.yaml
@@ -1,0 +1,16 @@
+commits:
+- commit_branch: master
+  commit_hash: abc123
+  distgit_dir: /home/test/data/test-package
+  distro_hash: zyx987
+  dt_build: '1541157889'
+  dt_commit: '1541157342.0'
+  dt_distro: '1535033997'
+  extended_hash: 'asdf567'
+  flags: '0'
+  id: '61971'
+  notes: OK
+  project_name: test-package
+  repo_dir: /home/test/data/test-package
+  rpms: 'test-package.rpm'
+  status: SUCCESS

--- a/tests/unit/dlrn/test_http_data/test_commit.yaml
+++ b/tests/unit/dlrn/test_http_data/test_commit.yaml
@@ -1,0 +1,15 @@
+commits:
+- commit_branch: master
+  commit_hash: abc123
+  distgit_dir: /home/test/data/test-package
+  distro_hash: zxy987
+  dt_build: '1541157889'
+  dt_commit: '1541157342.0'
+  dt_distro: '1535033997'
+  flags: '0'
+  id: '61971'
+  notes: OK
+  project_name: test-package
+  repo_dir: /home/test/data/test-package
+  rpms: 'test-package.rpm'
+  status: SUCCESS


### PR DESCRIPTION
When an extended hash is in use, DlrnHttpData did not generate the
proper URL to fetch data.

Refactored the commit and get_versions methods into properties.

Added a link property to the dlrn config files to set the initial dlrn symlink
to use. This can been overridden in the constructors.

Signed-off-by: Jason Joyce <fuzzball81@gmail.com>