### PR TITLE
Fixing a bug when a dlrn commit has extended_hash: 'None'

### DIFF
--- a/atkinson/dlrn/http_data.py
+++ b/atkinson/dlrn/http_data.py
@@ -136,7 +136,7 @@ class DlrnHttpData():
         second = self._commit_data['commit_hash'][2:4]
         third = self._commit_data['commit_hash']
         for key in ['dist_hash', 'extended_hash']:
-            if self._commit_data.get(key):
+            if self._commit_data.get(key, 'None') != 'None':
                 third += '_' + self._commit_data[key][0:8]
         return os.path.join(self.url,
                             first,

--- a/tests/unit/dlrn/test_http_data/test_commit.yaml
+++ b/tests/unit/dlrn/test_http_data/test_commit.yaml
@@ -3,6 +3,7 @@ commits:
   commit_hash: abc123
   distgit_dir: /home/test/data/test-package
   distro_hash: zxy987
+  extended_hash: 'None'
   dt_build: '1541157889'
   dt_commit: '1541157342.0'
   dt_distro: '1535033997'


### PR DESCRIPTION
Some dlrn commits have an extended_hash entry that is set to 'None'. The
generated url from that data was including the 'None'. Now if 'None' is
encountered, it is not included in the url generation.

Signed-off-by: Jason Joyce <fuzzball81@gmail.com>