### PR TITLE
Only run a browser on systems with a GUI.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,8 @@ try:
 	from urllib import pathname2url
 except:
 	from urllib.request import pathname2url
-
-webbrowser.open("file://" + pathname2url(os.path.abspath(sys.argv[1])))
+if os.environ.get('DISPLAY'):
+	webbrowser.open("file://" + pathname2url(os.path.abspath(sys.argv[1])))
 endef
 export BROWSER_PYSCRIPT
 


### PR DESCRIPTION
If a developer does not have a GUI running then
decline running the browser but perform the rest of the actions in the
target. If a command called a browser on a headless system an error could
occur. This checks for a display and if one is found in the environment
then launch the browser.

Signed-off-by: Jason Joyce <fuzzball81@gmail.com>