### PR TITLE
Adding an error reporting infrastructure

### DIFF
--- a/atkinson/errors/__init__.py
+++ b/atkinson/errors/__init__.py
@@ -1,0 +1,1 @@
+#! /usr/bin/env python

--- a/atkinson/errors/reporters/__init__.py
+++ b/atkinson/errors/reporters/__init__.py
@@ -1,0 +1,33 @@
+#! /usr/bin/env python
+"""
+General error report classes
+"""
+
+from abc import ABC, abstractmethod
+
+
+class BaseReport(ABC):
+    """ Abstract base class for error reports """
+
+    @classmethod
+    @abstractmethod
+    def new(cls, title, description, config):
+        """ Create a new report and return a report object """
+
+    @classmethod
+    @abstractmethod
+    def get(cls, report_id, config):
+        """ Get a current report object by ID """
+
+    @property
+    @abstractmethod
+    def report_id(self):
+        """ The id of the report """
+
+    @abstractmethod
+    def update(self, **kwargs):
+        """ Update the data on an active report """
+
+    @abstractmethod
+    def close(self):
+        """ Close out the report """

--- a/atkinson/errors/reporters/generic.py
+++ b/atkinson/errors/reporters/generic.py
@@ -1,0 +1,65 @@
+#! /usr/bin/env python
+""" Python logging based reporter """
+
+from atkinson.errors.reporters import BaseReport
+from atkinson.logging.logger import getLogger
+
+
+class GenericReporter(BaseReport):
+    """ Class for a generic reporter based on the logging module """
+
+    def __init__(self, title, logger):
+        """
+        Class constructor
+        :param logger: The logger to use
+        """
+        self.__title = title
+        self.__log = logger
+
+    @classmethod
+    def new(cls, title, description, config):
+        """
+        Create a new report
+        :param title: The title for the report
+        :param description: A description for the report
+        :param config: Configuration dictionary for the report
+        :return: A LoggingReporter instance
+        """
+        log = getLogger()
+        log.error(f"{title}: {description}")
+        return cls(title, log)
+
+    @classmethod
+    def get(cls, report_id, config):
+        """
+        Retrieve an active report
+        :param report_id: The unique id (the report title) for the report
+        :param config: Configuration dictionary for the report
+        :return: A LoggingReporter instance
+        """
+        return cls(report_id, getLogger())
+
+    @property
+    def report_id(self):
+        """
+        Return the unique id for this report
+        """
+        return self.__title
+
+    def update(self, **kwargs):
+        """
+        Update the report
+        :param kwargs: A dictionary of named arguments to report
+        """
+        if self.__log:
+            message = (f"{self.__title}:\n\t"
+                       + "\n\t".join([f"{key}: {value}"
+                                      for key, value in kwargs.items()]))
+            self.__log.error(message)
+
+    def close(self):
+        """
+        Close the report
+        """
+        self.__log.error(f"Closing report: {self.report_id}")
+        self.__log = None

--- a/tests/unit/errors/reporters/test_generic.py
+++ b/tests/unit/errors/reporters/test_generic.py
@@ -1,0 +1,100 @@
+#! /usr/bin/env python
+""" Tests for the GenericReporter reporter """
+
+from logging import Logger
+from unittest.mock import create_autospec, patch
+
+import pytest
+
+from atkinson.errors.reporters.generic import GenericReporter
+
+
+@pytest.fixture()
+def get_logger_mock():
+    """ Get the mock of the atkinson logging module. """
+
+    patcher = patch('atkinson.errors.reporters.generic.getLogger')
+    log = patcher.start()
+    log.return_value = create_autospec(Logger)
+    yield log
+    patcher.stop()
+
+
+def test_new(get_logger_mock):
+    """
+    Given we have a GenericReporter instance
+    When we call new
+    Then we get a GenericReporter object back and the logger is called
+    """
+
+    mock_log = get_logger_mock()
+    report = GenericReporter.new('Test', 'Test description', {})
+    assert isinstance(report, GenericReporter)
+    assert mock_log.error.called
+
+
+def test_get():
+    """
+    Given we have a report id and a GenericReporter instance
+    When we call get
+    Then we get a GenericReporter object back
+    """
+    report = GenericReporter.get('Test', {})
+    assert isinstance(report, GenericReporter)
+
+
+def test_report_id():
+    """
+    Given we have a GenericReporter instance
+    When we call object.report_id
+    Then we get back the report's title
+    """
+    title = 'Test'
+    report = GenericReporter.new('Test', 'Test Description', {})
+    assert report.report_id == title
+
+
+def test_update(get_logger_mock):
+    """
+    Given we have an existing report
+    When we call update with arguments
+    Then then a new error message is generated
+    """
+    expected = "Test:\n\tkey1: value1\n\tkey2: value2"
+    update_args = {'key1': 'value1', 'key2': 'value2'}
+    mock_log = get_logger_mock()
+    report = GenericReporter.new('Test', 'Test description', {})
+    report.update(**update_args)
+    assert mock_log.error.called
+    args, kwargs = mock_log.error.call_args
+    assert args == (expected,)
+    assert kwargs == {}
+
+
+def test_close(get_logger_mock):
+    """
+    Given we have an existing report
+    When we call close
+    Then an error message is generated
+    """
+    expected = "Closing report: Test"
+    mock_log = get_logger_mock()
+    report = GenericReporter.new('Test', 'Test description', {})
+    report.close()
+    assert mock_log.error.called
+    args, kwargs = mock_log.error.call_args
+    assert args == (expected,)
+    assert kwargs == {}
+
+
+def test_no_update_after_close(get_logger_mock):
+    """
+    Given we have an existing report
+    When we call close and then try to call update
+    Then an error message is not  generated
+    """
+    mock_log = get_logger_mock()
+    report = GenericReporter.get('Test', {})
+    report.close()
+    report.update(description='New description')
+    assert mock_log.error.call_count == 1

--- a/tox.ini
+++ b/tox.ini
@@ -14,8 +14,9 @@ commands =
 	python setup.py test
 
 [testenv:flake8]
+basepython = python3.6
 passenv = HOME
 deps = flake8
 sitepackages = False
 commands =
-    flake8 --ignore=E501 setup.py docs atkinson tests
+    flake8 --ignore=E501,W503 setup.py docs atkinson tests


### PR DESCRIPTION
Adding a  base error reporter.
The BaseReport class provides a consistent format for all reporters.
This ensures that any reporter can be used by an error without the error
having to know the internals of how a report is handled.

Adding a generic error reporter based on the logging module.
Adding a reporting structure for errors. These reports can be used for
internal errors or issues that may be encountered during normal
operation.

This report used the default logger which is based on the python logger.

Signed-off-by: Jason Joyce <fuzzball81@gmail.com>