### PR TITLE
Doc cleanup for the error reporters.

### DIFF
--- a/atkinson/errors/reporters/__init__.py
+++ b/atkinson/errors/reporters/__init__.py
@@ -12,22 +12,41 @@ class BaseReport(ABC):
     @classmethod
     @abstractmethod
     def new(cls, title, description, config):
-        """ Create a new report and return a report object """
+        """
+        Create a new report and return a report object
+
+        :param title: A title for the report (str)
+        :param description: Description for the report (str)
+        :param config: Configuration information for the report (dict)
+        """
 
     @classmethod
     @abstractmethod
     def get(cls, report_id, config):
-        """ Get a current report object by ID """
+        """
+        Get a current report object by ID
+
+        :param report_id: The ID for the report (str)
+        :param config: Configuration information for the report (dict)
+        """
 
     @property
     @abstractmethod
     def report_id(self):
-        """ The id of the report """
+        """
+        The id of the report
+        """
 
     @abstractmethod
     def update(self, **kwargs):
-        """ Update the data on an active report """
+        """
+        Update the data on an active report
+
+        :param kwargs: Name=value pairs of data to update in the report
+        """
 
     @abstractmethod
     def close(self):
-        """ Close out the report """
+        """
+        Close out the report
+        """

--- a/atkinson/errors/reporters/generic.py
+++ b/atkinson/errors/reporters/generic.py
@@ -11,6 +11,7 @@ class GenericReporter(BaseReport):
     def __init__(self, title, logger):
         """
         Class constructor
+
         :param logger: The logger to use
         """
         self.__title = title
@@ -20,6 +21,7 @@ class GenericReporter(BaseReport):
     def new(cls, title, description, config):
         """
         Create a new report
+
         :param title: The title for the report
         :param description: A description for the report
         :param config: Configuration dictionary for the report
@@ -33,6 +35,7 @@ class GenericReporter(BaseReport):
     def get(cls, report_id, config):
         """
         Retrieve an active report
+
         :param report_id: The unique id (the report title) for the report
         :param config: Configuration dictionary for the report
         :return: A LoggingReporter instance
@@ -49,6 +52,7 @@ class GenericReporter(BaseReport):
     def update(self, **kwargs):
         """
         Update the report
+
         :param kwargs: A dictionary of named arguments to report
         """
         if self.__log:


### PR DESCRIPTION
A space was missing between the method description and the parameters
causing the documentation to not render correctly.

Added additional missing documentation for the base class.

Signed-off-by: Jason Joyce <fuzzball81@gmail.com>