### PR TITLE
Adding a trello based error reporter.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -40,6 +40,7 @@ atkinson uses the upcoming standard of Pipfiles via pipenv.  This is integrated
 into our Makefile and once you have the above dependencies, you can simply run::
 
   make dev
+
 This will install our dev environment for the package via pipenv.  It is installed
 with --user, so it does not affect your site-packages.  Pipenv creates a unique virtualenv
 for us, which you can activate via::

--- a/atkinson/errors/reporters/__init__.py
+++ b/atkinson/errors/reporters/__init__.py
@@ -15,9 +15,9 @@ class BaseReport(ABC):
         """
         Create a new report and return a report object
 
-        :param title: A title for the report (str)
-        :param description: Description for the report (str)
-        :param config: Configuration information for the report (dict)
+        :param str title: A title for the report
+        :param str description: Description for the report
+        :param dict config: Configuration information for the report
         """
 
     @classmethod
@@ -26,8 +26,8 @@ class BaseReport(ABC):
         """
         Get a current report object by ID
 
-        :param report_id: The ID for the report (str)
-        :param config: Configuration information for the report (dict)
+        :param str report_id: The ID for the report
+        :param dict config: Configuration information for the report
         """
 
     @property

--- a/atkinson/errors/reporters/trello.py
+++ b/atkinson/errors/reporters/trello.py
@@ -1,0 +1,241 @@
+#! /usr/bin/env python
+""" Trello Card error reporter """
+
+import re
+
+from trollo import TrelloApi
+
+from atkinson.config.manager import ConfigManager
+from atkinson.errors.reporters import BaseReport
+
+
+def get_trello_api():
+    """
+    Construct an interface to trello using the trollo api
+    """
+    conf = ConfigManager('trello.yml').config
+    return TrelloApi(conf['api_key'], conf['token'])
+
+
+def get_columns(api, config):
+    """
+    Get the trello column ids for a trello board given a api handle and the id
+    of the board.
+
+    :param api: A trollo Boards api handle.
+    :param dict config: The configuration data (see note below for details).
+    :return: A tuple of column trello ids
+
+    .. note::
+        Required configuration keys and values
+            * board_id The trello board unique id
+            * new_column The name(str) of the column where new cards are added
+              This would be the same name as seen in the Trello webui
+            * close_column The name(str) of the column where closed/inactive
+              are moved.
+              This would be the same name as seen in the Trello webui
+    """
+    for key in ['board_id', 'new_column', 'close_column']:
+        if key not in config:
+            raise KeyError(f"A required key '{key}' is missing in the config")
+
+    column_data = {x['name']: x['id']
+                   for x in api.get_list(config['board_id'])}
+    return (column_data[config['new_column']],
+            column_data[config['close_column']])
+
+
+class TrelloCard(BaseReport):
+    """ Trello error card base class"""
+    def __init__(self, card_id, api, new_column, close_column):
+        """
+        Class constructor
+
+        :param str card_id: The trello unique id for the card to work on
+        :param api: A trollo TrelloApi instance
+        :param str new_column: The trello unique id for a column to place
+                               new cards
+        :param str close_column: The trello unique id for a column to place
+                                 completed cards
+        """
+        self.__card_id = card_id
+        self.__card_data = None
+        self.__checklist_items = {}
+        self.__new_column = new_column
+        self.__close_column = close_column
+        self.__api = api
+
+        # seed data from trello
+        self._get_card_data()
+        self._get_checklist_data()
+
+    @classmethod
+    def new(cls, title, description, config):
+        """
+        Create a TrelloCard instance
+
+        :param str title: A title for the trello card
+        :param str description: A description for the trello card
+        :param dict config: A configuration dictionary
+        :returns: A TrelloCard instance
+
+        .. note::
+            Required configuration keys and values
+                * board_id The trello board unique id
+                * new_column The name(str) of the column where new cards are added
+                  This would be the same name as seen in the Trello webui
+                * close_column The name(str) of the column where closed/inactive
+                  are moved.
+                  This would be the same name as seen in the Trello webui
+        """
+
+        api = get_trello_api()
+        # Get the trello ids for our columns in the config
+        new_column, close_column = get_columns(api.boards, config)
+        card_id = api.cards.new(title, new_column, description)['id']
+        return cls(card_id, api, new_column, close_column)
+
+    @classmethod
+    def get(cls, report_id, config):
+        """
+        Get a report object based on the report id.
+
+        :param str report_id: The id of the report to construct
+        :type report_id: Trello unique id
+        :param dict config: Reporter configuration dictionary
+        :return: A TrelloCard instance based on the report_id
+
+        .. note::
+            Required configuration keys and values
+                * board_id The trello board unique id
+                * new_column The name(str) of the column where new cards are added
+                  This would be the same name as seen in the Trello webui
+                * close_column The name(str) of the column where closed/inactive
+                  are moved.
+                  This would be the same name as seen in the Trello webui
+        """
+        api = get_trello_api()
+        # Get the trello ids for our columns in the config
+        new_column, close_column = get_columns(api.boards, config)
+        return cls(report_id, api, new_column, close_column)
+
+    def _get_card_data(self):
+        """ Fetch the cards data from Trello """
+        self.__card_data = self.__api.cards.get(self.__card_id)
+
+    def _get_checklist_data(self):
+        """ Fetch the checklist data from Trello """
+        for checklist in self.__card_data.get('idChecklists', []):
+            data = self.__api.checklists.get(checklist)
+            check_data = {'id': data['id'], 'items': {}}
+            for item in data['checkItems']:
+                name, link = self._markdown_to_tuple(item['name'])
+                check_data['items'][name] = item
+                check_data['items'][name]['link'] = link
+            self.__checklist_items[data['name']] = check_data
+
+    def _markdown_to_tuple(self, markdown):
+        """ Extract a tuple for a markdown formatted link """
+        if markdown.find('[') != -1:
+            match = re.search(r'\[(.+)\]\((.+)\)', markdown)
+            if match:
+                return (match.group(1), match.group(2))
+        else:
+            return (markdown, '')
+
+    def _dict_to_markdown(self, data):
+        """ Format a dict into a markdown link """
+        return f"[{data['name']}]({data.get('link', '')})"
+
+    def _add_checklist(self, checklist_name):
+        """ Add a new checklist """
+        self.__api.cards.new_checklist(self.__card_id, checklist_name)
+
+    def _update_checklist(self, checklist_items):
+        """ Check or uncheck checklist items """
+        # Makes sure we have the latest data from the card.
+        self._get_card_data()
+        self._get_checklist_data()
+
+        for checklist_name, list_items in checklist_items.items():
+            current_list = self.__checklist_items.get(checklist_name)
+            incoming = {x['name']: x['link'] for x in list_items}
+
+            # Process the items items
+            on_card = {x for x in current_list['items']}
+            sorted_items = set(list(incoming))
+            checked = {x for x in current_list['items']
+                       if current_list['items'][x]['state'] == 'complete'}
+
+            to_move_bottom = [current_list['items'][x]['id'] for x in checked]
+
+            # items to add
+            for item in sorted(sorted_items - on_card):
+                data = self._dict_to_markdown({'name': item,
+                                               'link': incoming[item]})
+                self.__api.checklists.new_checkItem(current_list['id'],
+                                                    data)
+
+            # items to check
+            for item in sorted((on_card - checked) - sorted_items):
+                item_id = current_list['items'][item]['id']
+                self.__api.cards.check_checkItem(self.__card_id, item_id)
+                if item_id not in to_move_bottom:
+                    to_move_bottom.append(item_id)
+
+            # items to uncheck and/or update
+            for item in sorted(checked & sorted_items):
+                work_item = current_list['items'][item]
+                self.__api.cards.uncheck_checkItem(self.__card_id,
+                                                   work_item['id'])
+                self.__api.cards.move_checkItem(self.__card_id,
+                                                work_item['id'], 'top')
+                to_move_bottom.remove(work_item['id'])
+
+            # Check for naming updates
+            for item in sorted(on_card & sorted_items):
+                work_item = current_list['items'][item]
+                if work_item['link'] != incoming[item]:
+                    new_name = self._dict_to_markdown({'name': item,
+                                                       'link': incoming[item]})
+                    self.__api.cards.rename_checkItem(self.__card_id,
+                                                      work_item['id'],
+                                                      new_name)
+
+            for item in to_move_bottom:
+                self.__api.cards.move_checkItem(self.__card_id,
+                                                item, 'bottom')
+
+    @property
+    def report_id(self):
+        return self.__card_id
+
+    def update(self, **kwargs):
+        """ Update the current report
+
+        :param kwargs: A dictionary of report items to update
+        """
+        if 'description' in kwargs:
+            self.__api.cards.update_desc(self.__card_id, kwargs['description'])
+
+        if 'checklist' in kwargs:
+            for checklist_name in kwargs['checklist']:
+                if checklist_name not in self.__checklist_items:
+                    self._add_checklist(checklist_name)
+
+            self._update_checklist(kwargs['checklist'])
+
+        # refresh card information.
+        self._get_card_data()
+        self._get_checklist_data()
+
+    def close(self):
+        """ Close report """
+        current_column = self.__card_data['idList']
+        clear_checklist = {x: {} for x in self.__checklist_items}
+
+        self._update_checklist(clear_checklist)
+
+        if current_column != self.__close_column:
+            self.__api.cards.update_idList(self.__card_id,
+                                           self.__close_column)

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -1,0 +1,10 @@
+Examples
+********
+
+Trello Configuration
+=========================
+The file format is standard YAML.
+
+.. include:: examples/trello.yml.example
+   :literal:
+

--- a/docs/examples/trello.yml.example
+++ b/docs/examples/trello.yml.example
@@ -1,0 +1,8 @@
+---
+
+# Your api key can be found at https://trello.com/app-key
+api_key: <your api_key>
+# You can generate a token from the app-key url as well.
+token: <your token>
+# This can be found by exporting the boad as json and looking for the id.
+board_id: <target board id>

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,6 +9,7 @@ Welcome to atkinson's documentation!
    installation
    usage
    source/modules
+   examples
    contributing
    authors
    history

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     ],
     description="Python based release manager.",
     setup_requires=['pytest-runner'],
-    install_requires=['toolchest>=0.0.4', 'requests'],
+    install_requires=['toolchest>=0.0.4', 'requests', 'trollo>=0.1.8'],
     tests_require=TEST_REQUIRES,
     extras_require={'docs': ['sphinx', 'sphinx-autobuild', 'sphinx-rtd-theme'],
                     'test': TEST_REQUIRES},

--- a/tests/unit/errors/reporters/test_trello.py
+++ b/tests/unit/errors/reporters/test_trello.py
@@ -1,0 +1,338 @@
+#! /usr/bin/env python
+""" Tests for the TrelloCard reporter """
+
+from unittest.mock import call, create_autospec, patch
+
+import pytest
+
+from trollo import Boards, Cards, Checklists, TrelloApi
+
+from atkinson.errors.reporters.trello import TrelloCard, get_columns
+
+
+@pytest.fixture()
+def get_api():
+    """ Trello Card api mock fixture """
+    patcher = patch('atkinson.errors.reporters.trello.get_trello_api')
+    func = patcher.start()
+    api_mock = create_autospec(TrelloApi)
+    api_mock.cards = create_autospec(Cards)
+    api_mock.checklists = create_autospec(Checklists)
+    api_mock.boards = create_autospec(Boards)
+    func.return_value = api_mock
+    yield func
+    patcher.stop()
+
+
+@pytest.fixture()
+def get_columns_mock():
+    """ Trello board column mock """
+    patcher = patch('atkinson.errors.reporters.trello.get_columns')
+    column = patcher.start()
+    column.return_value = ('123', '987')
+    yield column
+    patcher.stop()
+
+
+@pytest.fixture()
+def good_config():
+    """ A good configuration """
+    return {'board_id': 'abc123', 'new_column': 'a', 'close_column': 'b'}
+
+
+def get_instance(api):
+    """ Generate a TrelloCard instance """
+    return TrelloCard('card_id', api, '123', '987')
+
+
+def test_columns_good_config(get_api):
+    """
+    Given we have a proper config and a trello api handle
+    When we call get_columns
+    Then we get a tuple of trello column ids back
+    """
+    api = get_api()
+    api.boards.get_list.return_value = [{'name': 'a', 'id': '123'},
+                                        {'name': 'b', 'id': '456'}]
+    conf = {'board_id': 'abc123', 'new_column': 'a', 'close_column': 'b'}
+    expected = ('123', '456')
+    actual = get_columns(api.boards, conf)
+    assert actual == expected
+    assert api.boards.get_list.called
+
+
+@pytest.mark.parametrize('conf', [{},
+                                  {'board_id': 'abc123'},
+                                  {'board_id': 'abc123', 'new_column': 'a'},
+                                  {'board_id': 'abc123', 'close_column': 'b'},
+                                  {'new_column': 'a', 'close_column': 'b'}])
+def test_columns_bad_config(conf, get_api):
+    """
+    Given we have a bad config and a trello api handle
+    When we call get_columns
+    Then a KeyError exception is raised and the api is not called
+    """
+    with pytest.raises(KeyError):
+        api = get_api()
+        get_columns(api, conf)
+
+
+def test_new(get_api, get_columns_mock, good_config):
+    """
+    Given we have a TrelloCard instance
+    When we call new
+    Then we get a TrelloCard object back
+    """
+    api_mock = get_api()
+    api_mock.cards.new.return_value = {'id': '12345'}
+    card = TrelloCard.new('Test', 'Running a Test', good_config)
+    assert api_mock.cards.new.called
+    assert get_columns_mock.called
+    assert isinstance(card, TrelloCard)
+    assert card.report_id == '12345'
+
+
+def test_get(get_api, get_columns_mock, good_config):
+    """
+    Given we have a report_id and a configuration
+    When we call TrelloCard.get
+    Then we get a TrelloCard object back
+    """
+    api_mock = get_api()
+    api_mock.cards.get.return_value = {'idChecklists': ['12345'], 'id': '1234'}
+
+    api_mock.checklists.get.return_value = {'checkItems': [{'name': 'a',
+                                                            'id': '789'}],
+                                            'name': 'TestList',
+                                            'id': 'checklist_id'}
+
+    card = TrelloCard.get('1234', good_config)
+    assert api_mock.cards.get.called
+    assert api_mock.checklists.get.called
+    assert get_columns_mock.called
+    assert isinstance(card, TrelloCard)
+    assert card.report_id == '1234'
+
+
+def test_update_decription(get_api, get_columns_mock):
+    """
+    Given we have a TrelloCard instance
+    When we call update
+    And the description kwarg is available
+    Then the card_api update_desc method gets called
+    """
+    api_mock = get_api()
+    api_mock.cards.get.return_value = {'idChecklists': ['12345']}
+    api_mock.cards.update_desc.return_value = True
+
+    api_mock.checklists.get.return_value = {'checkItems': [{'name': 'a',
+                                                            'id': '1234'}],
+                                            'name': 'TestList',
+                                            'id': 'checklist_id'}
+
+    card = get_instance(api_mock)
+    card.update(description='New description')
+    assert api_mock.cards.update_desc.called
+    args, kwargs = api_mock.cards.update_desc.call_args
+    assert args == ('card_id', 'New description')
+    assert kwargs == {}
+
+
+def test_update_checklist_complete_url_match(get_api):
+    """
+    Given we have a TrelloCard instance
+    When we call update
+    And the checklist kwarg is available with only one checklist item left
+    And the url matches
+    Then the missing checklist item is marked complete.
+    """
+    api_mock = get_api
+    api_mock.cards.get.return_value = {'idChecklists': ['checklist_id'],
+                                       'id': 'card_id'}
+    api_mock.cards.check_checkItem.return_value = True
+    api_mock.cards.move_checkItem.return_value = True
+
+    checklist_ret = {'checkItems': [{'name': '[a](https://failing/a1)',
+                                     'id': '1234',
+                                     'state': 'incomplete'},
+                                    {'name': '[b](https://failing/b1)',
+                                     'id': '5678',
+                                     'state': 'incomplete'}],
+                     'name': 'TestList', 'id': 'checklist_id'}
+    api_mock.checklists.get.return_value = checklist_ret
+
+    card = get_instance(api_mock)
+    card.update(checklist={'TestList': [{'name': 'a',
+                                         'link': 'https://failing/a1'}]})
+    assert api_mock.cards.get.called
+    assert api_mock.checklists.get.called
+    assert api_mock.cards.check_checkItem.called
+    # Verify that only one checklist item was updated
+    args, kwargs = api_mock.cards.check_checkItem.call_args
+    assert args == ('card_id', '5678')
+    assert kwargs == {}
+    # Verify that 'a' was moved to the bottom of the list
+    assert api_mock.cards.move_checkItem.called
+    args2, kwargs2 = api_mock.cards.move_checkItem.call_args
+    assert args2 == ('card_id', '5678', 'bottom')
+    assert kwargs2 == {}
+
+
+def test_update_checklist_url_no_match(get_api):
+    """
+    Given we have a TrelloCard instance
+    When we call update
+    And the checklist kwarg is available with only one checklist item left
+    And the url does not match
+    Then the missing checklist item is marked complete.
+    """
+    api_mock = get_api
+    api_mock.cards.get.return_value = {'idChecklists': ['checklist_id'],
+                                       'id': 'card_id'}
+    api_mock.cards.rename_checkItem.return_value = True
+
+    checklist_ret = {'checkItems': [{'name': '[a](https://failing/a1)',
+                                     'id': '1234',
+                                     'state': 'incomplete'}],
+                     'name': 'TestList', 'id': 'checklist_id'}
+    api_mock.checklists.get.return_value = checklist_ret
+
+    card = get_instance(api_mock)
+    card.update(checklist={'TestList': [{'name': 'a',
+                                         'link': 'https://failing/a2'}]})
+    assert api_mock.cards.get.called
+    assert api_mock.checklists.get.called
+    assert not api_mock.checklists.new_checkItem.called
+    assert not api_mock.cards.uncheck_checkItem.called
+    assert api_mock.cards.rename_checkItem.called
+    args, kwargs = api_mock.cards.rename_checkItem.call_args
+    assert args == ('card_id', '1234', '[a](https://failing/a2)')
+    assert kwargs == {}
+
+
+def test_update_checklist_incomplete(get_api):
+    """
+    Given we have a TrelloCard instance
+    When we call update
+    And the checklist kwarg is available with two items listed
+    Then the added checklist item is marked incomplete.
+    """
+    api_mock = get_api
+    api_mock.cards.get.return_value = {'idChecklists': ['checklist_id'],
+                                       'id': 'card_id'}
+    api_mock.cards.uncheck_checkItem.return_value = True
+    api_mock.cards.check_checkItem.return_value = True
+    api_mock.cards.move_checkItem.return_value = True
+
+    checklist_ret = {'checkItems': [{'name': 'a',
+                                     'id': '1234',
+                                     'state': 'complete'},
+                                    {'name': 'b',
+                                     'id': '5678',
+                                     'state': 'incomplete'}],
+                     'name': 'TestList', 'id': 'checklist_id'}
+    api_mock.checklists.get.return_value = checklist_ret
+
+    card = get_instance(api_mock)
+    card.update(checklist={'TestList': [{'name': 'a', 'link': 'url/a'},
+                                        {'name': 'b', 'link': 'url/b'}]})
+    assert api_mock.checklists.get.called
+    assert api_mock.cards.uncheck_checkItem.called
+    # Check to see if 'a' was unchecked
+    args, kwargs = api_mock.cards.uncheck_checkItem.call_args
+    assert args == ('card_id', '1234')
+    assert kwargs == {}
+    # Check to makes sure nothing else was marked complete.
+    assert not api_mock.cards.check_checkItem.called
+    # Check to make sure 'a' was moved to the top of the list
+    assert api_mock.cards.move_checkItem.called
+    args2, kwargs2 = api_mock.cards.move_checkItem.call_args
+    assert args2 == ('card_id', '1234', 'top')
+    assert kwargs2 == {}
+
+
+def test_update_new_checklist(get_api):
+    """
+    Given we have a TrelloCard instance
+    When we call update
+    And we don't have an existing checklist
+    Then a checklist and all of the items are added.
+    """
+    api_mock = get_api
+    api_mock.cards.get.side_effect = [{'idChecklists': [], 'id': 'card_id'},
+                                      {'idChecklists': ['checklist_id'],
+                                       'id': 'card_id'},
+                                      {'idChecklists': ['checklist_id'],
+                                       'id': 'card_id'}]
+    api_mock.cards.new_checklist.return_value = {'id': 'checklist_id'}
+
+    checklist_ret = [{'name': 'TestList', 'id': 'checklist_id',
+                      'checkItems': []},
+                     {'checkItems': [{'name': '[a](url/a)',
+                                      'id': '1234',
+                                      'state': 'incomplete'},
+                                     {'name': '[b](url/b)',
+                                      'id': '5678',
+                                      'state': 'incomplete'}],
+                      'name': 'TestList', 'id': 'checklist_id'}]
+    api_mock.checklists.get.side_effect = checklist_ret
+    api_mock.checklists.new_checkItem.return_value = True
+
+    card = get_instance(api_mock)
+    card.update(checklist={'TestList': [{'name': 'a', 'link': 'url/a'},
+                                        {'name': 'b', 'link': 'url/b'}]})
+
+    api_mock.cards.new_checklist.assert_called_once()
+    assert api_mock.checklists.get.call_count == 2
+    assert api_mock.checklists.new_checkItem.call_count == 2
+    call_list = api_mock.checklists.new_checkItem.call_args_list
+    assert [call('checklist_id', '[a](url/a)'),
+            call('checklist_id', '[b](url/b)')] == call_list
+
+
+def test_close_empty(get_api):
+    """
+    Given we have a TrelloCard instance
+    When we call close
+    And the card does not have a checklist
+    Then none of the checklist api calls are made.
+    """
+    api_mock = get_api
+    api_mock.cards.get.return_value = {'idList': '123', 'id': 'card_id'}
+    api_mock.cards.update_idList.return_value = True
+
+    api_mock.checklists.get.return_value = {}
+
+    card = get_instance(api_mock)
+    card.close()
+    assert not api_mock.cards.check_checkItem.called
+    assert api_mock.cards.update_idList.called
+
+
+def test_close_complete_items(get_api):
+    """
+    Given we have a TrelloCard instance
+    When we call close
+    And the card has a checklist
+    Then the check_checkItem api is called for each item.
+    """
+    api_mock = get_api
+    api_mock.cards.get.return_value = {'idList': '123', 'id': 'card_id',
+                                       'idChecklists': ['checklist_id']}
+    api_mock.cards.check_checkItem.return_value = True
+
+    checklist_ret = {'checkItems': [{'name': 'a',
+                                     'id': '1234',
+                                     'state': 'incomplete'},
+                                    {'name': 'b',
+                                     'id': '5678',
+                                     'state': 'incomplete'}],
+                     'name': 'TestList', 'id': 'checklist_id'}
+    api_mock.checklists.get.return_value = checklist_ret
+
+    card = get_instance(api_mock)
+    card.close()
+    assert api_mock.cards.check_checkItem.called
+    call_list = api_mock.cards.check_checkItem.call_args_list
+    assert call_list == [call('card_id', '1234'), call('card_id', '5678')]
+    assert api_mock.cards.update_idList.called


### PR DESCRIPTION
The trello reporter creates and maintains trello cards via the trello
rest api. When a new report is created a card is added to the board
based on the configuration file. The report also has support for adding
checklist items to track progress.

The configuration file needs the api key and token from trello to be
able to access and update cards.

Signed-off-by: Jason Joyce <fuzzball81@gmail.com>