### PR TITLE
Fixing a bug in the trello markdown processing.

### DIFF
--- a/atkinson/errors/reporters/trello.py
+++ b/atkinson/errors/reporters/trello.py
@@ -137,7 +137,7 @@ class TrelloCard(BaseReport):
     def _markdown_to_tuple(self, markdown):
         """ Extract a tuple for a markdown formatted link """
         if markdown.find('[') != -1:
-            match = re.search(r'\[(.+)\]\((.+)\)', markdown)
+            match = re.search(r'\[(.+)\]\((.*)\)', markdown)
             if match:
                 return (match.group(1), match.group(2))
         else:


### PR DESCRIPTION
The regex being used for breaking apart a markdown link was too
restrictive. If the url portion was empty then a NoneType exception was
being thrown. Allowing a empty url fixes this issue.

Added a unit test that covers this case.

Signed-off-by: Jason Joyce <fuzzball81@gmail.com>