### PR TITLE
Adding a dlrn failed to build from source error.

### DIFF
--- a/atkinson/errors/__init__.py
+++ b/atkinson/errors/__init__.py
@@ -1,1 +1,33 @@
 #! /usr/bin/env python
+"""
+Base error class for Atkinson operations
+
+Each of the errors atkinson can raise should use this base class. This will
+ensure that each error can be acted upon and has the needed properties
+"""
+
+from abc import ABC, abstractmethod
+
+
+class BaseError(ABC):
+    """Atkinson base error class"""
+
+    @property
+    @abstractmethod
+    def message(self):
+        """The error message to use/log"""
+
+    @abstractmethod
+    def action(self):
+        """
+        The action to take on this error.
+        This make be logging or displaying an error to more advanced error
+        handling
+        """
+
+    @abstractmethod
+    def clear(self):
+        """
+        Perform error clear actions.
+        This may be updating logging or more advanced error clearing methods
+        """

--- a/atkinson/errors/dlrn.py
+++ b/atkinson/errors/dlrn.py
@@ -1,0 +1,69 @@
+#! /usr/bin/env python
+"""
+Atkinson Dlrn Error Handling.
+
+The error classes here are for errors that occur when interacting with dlrn
+and not errors in the atkinson application itself.
+"""
+import datetime
+import os.path
+
+from atkinson.errors import BaseError
+
+
+class DlrnFTBFSError(BaseError):
+    """
+    DLRN Failing To Build From Source Error handler
+
+    :param str release: String name for the release the error was found
+    :param dict config: Dictionary of configuration data for the reporter
+    :param BaseReport reporter: A reporter to use for this error
+    :param str error_id: An error report id to be used (Default None)
+    """
+    def __init__(self, release, config, reporter, error_id=None):
+        self.__release = release
+        self.__conf = config
+        self.__packages = None
+        self.__report = None
+        self.__reporter = reporter
+
+        if error_id:
+            self.__report = self.__reporter.get(error_id, config)
+        else:
+            title = self.__conf.get('title') + f"[{release}]"
+            self.__report = self.__reporter.new(title,
+                                                self.message,
+                                                self.__conf)
+
+    @property
+    def id(self):
+        """ Return the id for the error """
+        return self.__report.report_id
+
+    @property
+    def packages(self):
+        """ The list packages that failed to build """
+        return self.__packages
+
+    @packages.setter
+    def packages(self, packages):
+        self.__packages = {'Failing Builds': packages}
+
+    @property
+    def message(self):
+        """ The error massage to display """
+        url = os.path.join(self.__conf.get('url', ''), 'status_report.html')
+        message = (f"Results as of: {datetime.datetime.utcnow()} UTC\n"
+                   f"Build Details: {url}")
+        return message
+
+    def action(self):
+        """ Run reporting actions """
+
+        if self.packages:
+            self.__report.update(description=self.message,
+                                 checklist=self.packages)
+
+    def clear(self):
+        self.__report.update(description=self.message)
+        self.__report.close()

--- a/tests/unit/errors/test_dlrn.py
+++ b/tests/unit/errors/test_dlrn.py
@@ -1,0 +1,148 @@
+#! /usr/bin/env python
+"""Test for the DLRN error handlers"""
+
+from unittest.mock import create_autospec
+
+import pytest
+
+from atkinson.errors import BaseError
+from atkinson.errors.dlrn import DlrnFTBFSError
+from atkinson.errors.reporters import BaseReport
+
+
+@pytest.fixture(scope='module')
+def get_config():
+    """ Test config generator """
+    return {'url': 'test/url',
+            'title': 'Test Error'}
+
+
+@pytest.fixture()
+def get_reporter():
+    """ Test reporter mock generator """
+    reporter = create_autospec(BaseReport)
+    return reporter
+
+
+@pytest.fixture()
+def get_report():
+    """ Test reporter mock generator """
+    report = create_autospec(BaseReport)
+    return report
+
+
+def test_is_base(get_config, get_reporter):
+    """
+    Given we have DlrnFTBFSError object
+    When we check the subclass is BaseError
+    Then we get True
+    """
+    assert issubclass(DlrnFTBFSError, BaseError)
+
+
+def test_packages(get_config, get_reporter):
+    """
+    Given we have a DlrnFTBFSError instance
+    When we set the packages property
+    Then we get the same list of packages
+    """
+    packs = ['my_package']
+    expected = {'Failing Builds': packs}
+    error = DlrnFTBFSError('Test Release', get_config, get_reporter)
+    error.packages = packs
+    assert expected == error.packages
+
+
+def test_message(get_config, get_reporter):
+    """
+    Given we have a DlrnFTBFSError instance
+    When we access the message property
+    Then we get a non-empty string
+    """
+    error = DlrnFTBFSError('Test Release', get_config, get_reporter)
+    assert error.message != ''
+
+
+def test_error_id_calls_get(get_config, get_reporter):
+    """
+    Given we have a DlrnFTBFSError instance
+    And it was initialized with an error id
+    When object initialization is complete
+    Then we have a call to fetch a report for that error id.
+    """
+    reporter = get_reporter
+    DlrnFTBFSError('Test Release', get_config, reporter, error_id='1234')
+    assert reporter.get.called
+    args, kwargs = reporter.get.call_args
+    assert args == ('1234', get_config)
+    assert kwargs == {}
+
+
+def test_action_raises_new_report(get_config, get_reporter):
+    """
+    Given we have a DlrnFTBFSError instance
+    And no active reports and no packages
+    When we call action
+    Then a new report is created
+    """
+    reporter = get_reporter
+    conf = get_config
+    error = DlrnFTBFSError('Test Release', conf, reporter)
+    error.action()
+    assert reporter.new.called
+    assert not reporter.update.called
+
+
+def test_action_raises_new_report_packages(get_config,
+                                           get_reporter, get_report):
+    """
+    Given we have a DlrnFTBFSError instance
+    And no active reports and has packages
+    When we call action
+    Then a new report is created and update is called
+    """
+    reporter = get_reporter
+    report = get_report
+    reporter.new.return_value = report
+    error = DlrnFTBFSError('Test Release', get_config, reporter)
+    error.packages = ['my_bad_package']
+    error.action()
+    assert reporter.new.called
+    assert report.update.called
+
+
+def test_existing_updates(get_config, get_reporter, get_report):
+    """
+    Given we have a DlrnFTBFSError instance
+    And an active report and have packages
+    When we call action
+    Then the existing report is updated.
+    """
+    reporter = get_reporter
+    report = get_report
+    reporter.get.return_value = report
+    error = DlrnFTBFSError('Test Release', get_config, reporter,
+                           error_id='1234')
+    error.packages = ['my_bad_package']
+    error.action()
+    assert reporter.get.called
+    assert not reporter.new.called
+    assert report.update.called
+
+
+def test_close(get_config, get_reporter, get_report):
+    """
+    Given we have a DlrnFTBFSError instance
+    And an active report
+    When we call clear
+    Then the report is updated and cleared.
+    """
+    reporter = get_reporter
+    report = get_report
+    reporter.get.return_value = report
+    error = DlrnFTBFSError('Test Release', get_config, reporter,
+                           error_id='1234')
+    error.clear()
+    assert reporter.get.called
+    assert report.update.called
+    assert report.close.called


### PR DESCRIPTION
The first error that you can encounter from dlrn is packages failing to
build. The DlrnFTBFSError is the handler for these types of errors. The
class files and maintains the error through it's lifecycle. This type of
error needs a package maintainer to look into it, so the action is
simply to report the error via a reporter.

A BaseError pattern is also established so future errors can be handled
in a consistent manner.

Signed-off-by: Jason Joyce <fuzzball81@gmail.com>