### PR TITLE
Update trello card position on report close

### DIFF
--- a/atkinson/errors/reporters/trello.py
+++ b/atkinson/errors/reporters/trello.py
@@ -239,3 +239,4 @@ class TrelloCard(BaseReport):
         if current_column != self.__close_column:
             self.__api.cards.update_idList(self.__card_id,
                                            self.__close_column)
+            self.__api.cards.update_pos(self.__card_id, 'bottom')

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     ],
     description="Python based release manager.",
     setup_requires=['pytest-runner'],
-    install_requires=['toolchest>=0.0.4', 'requests', 'trollo>=0.1.8'],
+    install_requires=['toolchest>=0.0.4', 'requests', 'trollo>=0.1.9'],
     tests_require=TEST_REQUIRES,
     extras_require={'docs': ['sphinx', 'sphinx-autobuild', 'sphinx-rtd-theme'],
                     'test': TEST_REQUIRES},

--- a/tests/unit/errors/reporters/test_trello.py
+++ b/tests/unit/errors/reporters/test_trello.py
@@ -332,6 +332,7 @@ def test_close_empty(get_api):
     api_mock = get_api
     api_mock.cards.get.return_value = {'idList': '123', 'id': 'card_id'}
     api_mock.cards.update_idList.return_value = True
+    api_mock.cards.update_pos.return_value = True
 
     api_mock.checklists.get.return_value = {}
 
@@ -339,6 +340,7 @@ def test_close_empty(get_api):
     card.close()
     assert not api_mock.cards.check_checkItem.called
     assert api_mock.cards.update_idList.called
+    assert api_mock.cards.update_pos.called
 
 
 def test_close_complete_items(get_api):
@@ -361,6 +363,7 @@ def test_close_complete_items(get_api):
                                      'state': 'incomplete'}],
                      'name': 'TestList', 'id': 'checklist_id'}
     api_mock.checklists.get.return_value = checklist_ret
+    api_mock.cards.update_pos.return_value = True
 
     card = get_instance(api_mock)
     card.close()
@@ -368,3 +371,4 @@ def test_close_complete_items(get_api):
     call_list = api_mock.cards.check_checkItem.call_args_list
     assert call_list == [call('card_id', '1234'), call('card_id', '5678')]
     assert api_mock.cards.update_idList.called
+    assert api_mock.cards.update_pos.called


### PR DESCRIPTION
By default when a card is moved to a new list, the card is not
guaranteed to be at the bottom of the new this. On report close we will
force the card to be at the bottom of it's completed list.

Signed-off-by: Jason Joyce <fuzzball81@gmail.com>